### PR TITLE
Switch Livy tests to use jars

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -28,8 +28,7 @@ livy_validate_http_response <- function(message, req) {
 livy_available_jars <- function() {
   system.file("java", package = "sparklyr") %>%
     dir(pattern = "sparklyr") %>%
-    gsub("^sparklyr-|-.*\\.jar", "", .) %>%
-    numeric_version()
+    gsub("^sparklyr-|-.*\\.jar", "", .)
 }
 
 #' Create a Spark Configuration for Livy
@@ -559,7 +558,15 @@ livy_connection_jars <- function(config, version) {
 
   if (!spark_config_value(config, "sparklyr.livy.sources", FALSE)) {
     major_version <- gsub("\\.$", "", version)
-    previouis_versions <- Filter(function(maybe_version) maybe_version <= major_version, livy_available_jars())
+
+    livy_jars <- livy_available_jars()
+    livy_max_version <- max(numeric_version(livy_jars[livy_jars != "master"]))
+
+    previouis_versions <- Filter(
+      function(maybe_version) maybe_version <= major_version,
+      numeric_version(gsub("master", paste(livy_max_version, "1", sep = "."), livy_available_jars()))
+    )
+
     target_version <- previouis_versions[length(previouis_versions)]
 
     target_jar <- dir(system.file("java", package = "sparklyr"), pattern = paste0("sparklyr-", target_version))

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -202,6 +202,7 @@ testthat_livy_connection <- function() {
         sparklyr.connect.timeout = 120,
         sparklyr.log.invoke = "cat"
       ),
+      version = version,
       sources = TRUE
     )
 


### PR DESCRIPTION
Currently, we run tests using source-code-based Livy (which uploads the sparklyr backend as a source); however, we want to deprecate this mode in Spark 3.0 to simplify our codebase. This PR specifies the version with `method = "livy"` which would make the connection use the correct GitHub jar when connecting.