### PR TITLE
Improve documentation for the `columns` argument

### DIFF
--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -60,6 +60,11 @@ spark_csv_options <- function(header,
 #' @param header Boolean; should the first row of data be used as a header?
 #'   Defaults to \code{TRUE}.
 #' @param columns A vector of column names or a named vector of column types.
+#'   If specified, the elements can be \code{"binary"} for \code{BinaryType},
+#'   \code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+#'   \code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+#'   \code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+#'   \code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.
 #' @param infer_schema Boolean; should column types be automatically inferred?
 #'   Requires one extra pass over the data. Defaults to \code{is.null(columns)}.
 #' @param delimiter The character used to delimit each column. Defaults to \samp{','}.

--- a/man/spark_read_csv.Rd
+++ b/man/spark_read_csv.Rd
@@ -21,7 +21,12 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 \item{header}{Boolean; should the first row of data be used as a header?
 Defaults to \code{TRUE}.}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{infer_schema}{Boolean; should column types be automatically inferred?
 Requires one extra pass over the data. Defaults to \code{is.null(columns)}.}

--- a/man/spark_read_jdbc.Rd
+++ b/man/spark_read_jdbc.Rd
@@ -23,7 +23,12 @@ is, should the table be cached?)}
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_read_json.Rd
+++ b/man/spark_read_json.Rd
@@ -27,7 +27,12 @@ is, should the table be cached?)}
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_read_orc.Rd
+++ b/man/spark_read_orc.Rd
@@ -27,7 +27,12 @@ is, should the table be cached?)}
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{schema}{A (java) read schema. Useful for optimizing read operation on nested data.}
 

--- a/man/spark_read_parquet.Rd
+++ b/man/spark_read_parquet.Rd
@@ -27,7 +27,12 @@ is, should the table be cached?)}
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{schema}{A (java) read schema. Useful for optimizing read operation on nested data.}
 

--- a/man/spark_read_source.Rd
+++ b/man/spark_read_source.Rd
@@ -29,7 +29,12 @@ is, should the table be cached?)}
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_read_table.Rd
+++ b/man/spark_read_table.Rd
@@ -20,7 +20,12 @@ generated table. Use 0 (the default) to avoid partitioning.}
 \item{memory}{Boolean; should the data be loaded eagerly into memory? (That
 is, should the table be cached?)}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/stream_read_csv.Rd
+++ b/man/stream_read_csv.Rd
@@ -19,7 +19,12 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 \item{header}{Boolean; should the first row of data be used as a header?
 Defaults to \code{TRUE}.}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{delimiter}{The character used to delimit each column. Defaults to \samp{','}.}
 

--- a/man/stream_read_json.Rd
+++ b/man/stream_read_json.Rd
@@ -15,7 +15,12 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 
 \item{name}{The name to assign to the newly generated stream.}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{options}{A list of strings with additional options.}
 

--- a/man/stream_read_orc.Rd
+++ b/man/stream_read_orc.Rd
@@ -15,7 +15,12 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 
 \item{name}{The name to assign to the newly generated stream.}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{options}{A list of strings with additional options.}
 

--- a/man/stream_read_parquet.Rd
+++ b/man/stream_read_parquet.Rd
@@ -15,7 +15,12 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 
 \item{name}{The name to assign to the newly generated stream.}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{options}{A list of strings with additional options.}
 

--- a/man/stream_read_socket.Rd
+++ b/man/stream_read_socket.Rd
@@ -12,7 +12,12 @@ stream_read_socket(sc, name = NULL, columns = NULL, options = list(),
 
 \item{name}{The name to assign to the newly generated stream.}
 
-\item{columns}{A vector of column names or a named vector of column types.}
+\item{columns}{A vector of column names or a named vector of column types.
+If specified, the elements can be \code{"binary"} for \code{BinaryType},
+\code{"boolean"} for \code{BooleanType}, \code{"byte"} for \code{ByteType},
+\code{"integer"} for \code{IntegerType}, \code{"integer64"} for \code{LongType},
+\code{"double"} for \code{DoubleType}, \code{"character"} for \code{StringType},
+\code{"timestamp"} for \code{TimestampType} and \code{"date"} for \code{DateType}.}
 
 \item{options}{A list of strings with additional options.}
 


### PR DESCRIPTION
This proposes a small improvement to the docs of the `read_` functions in case the user wants to specify the `columns` argument. It provides an example mapping for each of `spark.sql.types`.