### PR TITLE
Support for DBI 1.1 by implementing dbQuoteLiteral

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ matrix:
         - r-lib/rlang
         - rstudio/forge
         - r-lib/ellipsis
+        - r-dbi/DBI
   allow_failures:
     - env: R_DEVEL_PACKAGES="true"
     - r: release

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 1.0.5.9001
+Version: 1.0.5.9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Fixed typo in `stream_read_socket()`.
 
+### Data
+
+- Add support for `DBI 1.1` to implement missing `dbQuoteLiteral` signature (#2227).
+
 # Sparklyr 1.0.5
 
 ### Serialization

--- a/R/dbi_spark_connection.R
+++ b/R/dbi_spark_connection.R
@@ -30,6 +30,11 @@ setMethod("sqlInterpolate", "spark_connection", function(conn, sql, ..., .dots =
   method(conn, sql, ..., .dots = .dots)
 })
 
+setMethod("dbQuoteLiteral", "spark_connection", function(conn, x, ...) {
+  method <- getMethod("dbQuoteLiteral", "DBIConnection")
+  method(conn, x, ...)
+})
+
 get_data_type <- function(obj) {
   if (is.factor(obj)) return("TEXT")
 


### PR DESCRIPTION
Travis is failing with `DBI 1.1` with:

```
Context: dbi
dbWriteTable can write a table: skip: Reason: tables not supported before 2.0.0 
dbGetQuery works with parameterized queries: error: unable to find an inherited method for function ‘dbQuoteLiteral’ for signature ‘"spark_connection"’ 
dbWriteTable can write a table: 0.0556514263153076
dbGetQuery works with parameterized queries: 0.00956606864929199
```