### PR TITLE
Add support for partition_by in spark_write_delta()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 1.0.5.9004
+Version: 1.0.5.9005
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@
 
 - Add config `sparklyr.livy.jar` to configure path or URL to sparklyr JAR.
 
+# Data
+
+- Add support for `partition_by` when using `spark_write_delta()` (#2228).
+
 # Sparklyr 1.0.5
 
 ### Serialization

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -951,9 +951,10 @@ spark_write_delta <- function(x,
                               path,
                               mode = NULL,
                               options = list(),
+                              partition_by = NULL,
                               ...) {
   options$path <- path
-  spark_write_source(x, "delta", mode = mode, options = options)
+  spark_write_source(x, "delta", mode = mode, options = options, partition_by = partition_by)
 }
 
 #' Read from Delta Lake into a Spark DataFrame.

--- a/man/spark-connections.Rd
+++ b/man/spark-connections.Rd
@@ -70,10 +70,8 @@ is being used.}
 These routines allow you to manage your connections to Spark.
 }
 \details{
-When using \code{method = "livy"}, it is recommended to specify \code{version}
-parameter to improve performance by using precompiled code rather than uploading
-sources. By default, jars are downloaded from GitHub but the path to the correct
-\code{sparklyr} JAR can also be specified through the \code{livy.jars} setting.
+When using \code{method = "livy"}, jars are downloaded from GitHub but the path
+to a local \code{sparklyr} JAR can also be specified through the \code{livy.jars} setting.
 }
 \examples{
 

--- a/man/spark_write_delta.Rd
+++ b/man/spark_write_delta.Rd
@@ -4,7 +4,8 @@
 \alias{spark_write_delta}
 \title{Writes a Spark DataFrame into Delta Lake}
 \usage{
-spark_write_delta(x, path, mode = NULL, options = list(), ...)
+spark_write_delta(x, path, mode = NULL, options = list(),
+  partition_by = NULL, ...)
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
@@ -20,6 +21,8 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
   for your version of Spark.}
 
 \item{options}{A list of strings with additional options.}
+
+\item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
 }


### PR DESCRIPTION
Fix for #2228 to enable:

```r
library(sparklyr)
sc <- spark_connect(master = "local", version = "2.4", packages = "delta")

copy_to(sc, iris) %>%
  spark_write_delta(path = "test", partition_by = "Species")
```
