### PR TITLE
Add sdf_drop_duplicates

### DIFF
--- a/R/sdf_interface.R
+++ b/R/sdf_interface.R
@@ -479,3 +479,29 @@ sdf_describe <- function(x, cols = colnames(x)) {
     invoke("describe", cols) %>%
     sdf_register()
 }
+
+#' Remove duplicates from a Spark DataFrame
+#'
+#' @param x An object coercible to a Spark DataFrame
+#' @param cols Subset of Columns to consider, given as a character vector
+#' @export
+sdf_drop_duplicates <- function(x, cols = NULL) {
+  in_df <- cols %in% colnames(x)
+
+  if (any(!in_df)) {
+    msg <- paste0("The following columns are not in the data frame: ",
+                  paste0(cols[which(!in_df)], collapse = ", "))
+    stop(msg)
+  }
+
+  cols <- cast_character_list(cols, allow_null=TRUE)
+  sdf <- spark_dataframe(x)
+
+  sdf_deduplicated <- if(is.null(cols)) {
+    invoke(sdf, "dropDuplicates")
+  } else {
+    invoke(sdf, "dropDuplicates", cols)
+  }
+
+  sdf_register(sdf_deduplicated)
+}

--- a/tests/testthat/test-sdf-drop-duplicates.R
+++ b/tests/testthat/test-sdf-drop-duplicates.R
@@ -1,0 +1,24 @@
+context("drop-duplicates")
+
+test_requires("dplyr")
+
+sc <- testthat_spark_connection()
+
+test_that("sdf_describe() works properly", {
+  iris_tbl <- testthat_tbl("iris")
+
+  s <- iris_tbl %>%
+    select(Petal_Length, Species) %>%
+    sdf_drop_duplicates()
+
+  expect_equal(sdf_nrow(s), 48)    
+
+  s <- iris_tbl %>% sdf_drop_duplicates(c("Species"))
+  expect_equal(sdf_nrow(s), 3)
+})
+
+test_that("sdf_drop_duplicates() checks column name", {
+  iris_tbl <- testthat_tbl("iris")
+  expect_error(sdf_drop_duplicates(iris_tbl, c("Sepal_Length", "foo")),
+               "The following columns are not in the data frame: foo")
+})


### PR DESCRIPTION
This PR adds a wrapper for `Dataset.dropDuplicates` method.

It can be used for efficient deduplication of records when particular choice of row doesn't matter, roughly equivalent to:

```r
distinct(iris, Species, .keep_all = TRUE)
```

with plain `data.frame`, which doesn't seem to play well with `sparklyr`

```r
distinct(iris_tbl, Species, .keep_all = TRUE)
## Error: Can only find distinct value of specified columns if .keep_all is FALSE
```

Additionally it has special meaning for streaming datasets.