### PR TITLE
Basic support in 'copy_to()' for data frames with list columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Sparklyr 1.1.0.9000
+
+### Data
+
+- Add support in `copy_to()` for columns with nested lists.
+
 # Sparklyr 1.1.0
 
 ### Distributed R

--- a/R/data_copy.R
+++ b/R/data_copy.R
@@ -209,11 +209,9 @@ spark_data_copy <- function(
     stop("Using a local file to copy data is not supported for remote clusters")
   }
 
-  json_column <- list()
-  if (!"data.frame" %in% class(df) || "list" %in% sapply(df, class)) {
+  if ("list" %in% sapply(df, class)) {
     for (column in colnames(df)) {
       if (class(df[[column]]) == "list") {
-        json_column <- list(json_column, column)
         df[[column]] <- sapply(df[[column]], function(e) jsonlite::toJSON(e))
       }
     }

--- a/R/data_copy.R
+++ b/R/data_copy.R
@@ -209,6 +209,16 @@ spark_data_copy <- function(
     stop("Using a local file to copy data is not supported for remote clusters")
   }
 
+  json_column <- list()
+  if (!"data.frame" %in% class(df) || "list" %in% sapply(df, class)) {
+    for (column in colnames(df)) {
+      if (class(df[[column]]) == "list") {
+        json_column <- list(json_column, column)
+        df[[column]] <- sapply(df[[column]], function(e) jsonlite::toJSON(e))
+      }
+    }
+  }
+
   serializer <- ifelse(
                   is.null(serializer),
                   ifelse(
@@ -229,6 +239,7 @@ spark_data_copy <- function(
     "csv_file_scala" = spark_serialize_csv_scala,
     "arrow" = spark_serialize_arrow
   )
+
 
   df <- spark_data_perform_copy(sc, serializers[[serializer]], df, repartition)
 

--- a/tests/testthat/test-copy-to.R
+++ b/tests/testthat/test-copy-to.R
@@ -55,3 +55,21 @@ test_that("sdf_copy_to supports list of callbacks", {
     4
   )
 })
+
+test_that("sdf_copy_to works for json serializer", {
+  dfjson <- tibble::tibble(
+    g = c(1, 2, 3),
+    data = list(
+      tibble::tibble(x = 1, y = 2),
+      tibble::tibble(x = 4:5, y = 6:7),
+      tibble::tibble(x = 10)
+    )
+  )
+
+  dfjson_tbl <- sdf_copy_to(sc, dfjson, overwrite = TRUE)
+
+  expect_equal(
+    sdf_nrow(dfjson_tbl),
+    3
+  )
+})


### PR DESCRIPTION
DataFrames with list-columns can't currently be copied to Spark using `copy_to()`, since the structure is arbitrary, this fix transforms them to JSON columns to unblock the copy operation.

```r
library(sparklyr)
sc <- spark_connect(master = "local")

dfjson <- tibble::tibble(
    g = c(1, 2, 3),
    data = list(
      tibble::tibble(x = 1, y = 2),
      tibble::tibble(x = 4:5, y = 6:7),
      tibble::tibble(x = 10)
    )
)

dfjson <- copy_to(sc, dfjson, overwrite = TRUE)
dfjson
```
```
# Source: spark<dfjson> [?? x 2]
      g data                                   
  <dbl> <chr>                                  
1     1 "[{\"x\":1,\"y\":2}]"                  
2     2 "[{\"x\":4,\"y\":6},{\"x\":5,\"y\":7}]"
3     3 "[{\"x\":10}]"
```

One can then use `get_json_object()` to retrieve the content,

```r
dfjson %>% dplyr::mutate(data = get_json_object(data, "$[0].x"))
```
```
# Source: spark<?> [?? x 2]
      g data 
  <dbl> <chr>
1     1 1    
2     2 4    
3     3 10   
```