### PR TITLE
Support JDK11 for Spark 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ matrix:
       env:
         - SPARK_VERSION="master"
         - JAVA_VERSION=oraclejdk8
+    - name: "Spark master (R release, openjdk11)"
+      r: release
+      env:
+        - SPARK_VERSION="master"
+        - JAVA_VERSION=openjdk11
     - name: "Livy 0.5.0 (R release, oraclejdk8, Spark 2.3.0)"
       r: release
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       r: release
       env:
         - SPARK_VERSION="master"
-        - JAVA_VERSION=openjdk11
+        - JAVA_URL=JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
     - name: "Livy 0.5.0 (R release, oraclejdk8, Spark 2.3.0)"
       r: release
       env:
@@ -123,7 +123,12 @@ matrix:
             - openjdk-8-jre
 
 before_install:
-  - if [[ ! -z "$JAVA_VERSION" ]]; then jdk_switcher use $JAVA_VERSION ; fi
+  - if [[ ! -z "$JAVA_VERSION" ]]; then jdk_switcher use $JAVA_VERSION;  fi
+  - |
+    if [[ ! -z "$JAVA_URL" ]]; then
+      wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+      source install-jdk.sh --url $JAVA_URL
+    fi
   - echo $JAVA_HOME
   - if [[ ! -z "$ARROW_VERSION" ]]; then chmod +x ./ci/arrow-$ARROW_SOURCE.sh ; "./ci/arrow-$ARROW_SOURCE.sh" $ARROW_VERSION; fi
   - if [[ $SPARK_VERSION == "master" ]]; then chmod +x ./ci/spark-master-install.sh ; "./ci/spark-master-install.sh"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       r: release
       env:
         - SPARK_VERSION="master"
-        - JAVA_URL=JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
+        - JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
     - name: "Livy 0.5.0 (R release, oraclejdk8, Spark 2.3.0)"
       r: release
       env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 1.1.0.9000
+Version: 1.1.0.9001
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# Sparklyr 1.1.0.9000
+# Sparklyr 1.1.0.9001
+
+### Connection
+
+- Add support for JDK11 for Spark 3 preview.
 
 ### Data
 

--- a/R/java.R
+++ b/R/java.R
@@ -93,11 +93,13 @@ validate_java_version_line <- function(master, version) {
     stop("Java version detected but couldn't parse version from: ", versionLine)
 
   # ensure Java 1.7 or higher
-  if (compareVersion(parsedVersion, "1.7") < 0)
+  if (compareVersion(parsedVersion, "1.7")  == -1)
     stop("Java version", parsedVersion, " detected but 1.7+ is required. Please download and install Java from ",
          java_install_url())
 
-  if (compareVersion(parsedVersion, "1.9") >= 0 && spark_master_is_local(master)  && !getOption("sparklyr.java9", FALSE)) {
+  if (compareVersion(parsedVersion, "1.9") == 1 &&
+      compareVersion(parsedVersion, "11") == -1 &&
+      spark_master_is_local(master)  && !getOption("sparklyr.java9", FALSE)) {
     stop(
       "Java 9 is currently unsupported in Spark distributions unless you manually install Hadoop 2.8 ",
       "and manually configure Spark. Please consider uninstalling Java 9 and reinstalling Java 8. ",

--- a/R/java.R
+++ b/R/java.R
@@ -101,7 +101,7 @@ validate_java_version_line <- function(master, version) {
     stop("Java version", parsedVersion, " detected but 1.7+ is required. Please download and install Java from ",
          java_install_url())
 
-  if (compareVersion(parsedVersion, "1.9") == 1 &&
+  if (compareVersion(parsedVersion, "1.9") >= 0 &&
       compareVersion(parsedVersion, "11") == -1 &&
       spark_master_is_local(master)  && !getOption("sparklyr.java9", FALSE)) {
     stop(

--- a/R/java.R
+++ b/R/java.R
@@ -72,10 +72,13 @@ validate_java_version_line <- function(master, version) {
   if (length(versionLine) != 1)
     stop("Java version detected but couldn't parse version from ", paste(version, collapse = " - "))
 
-  # transform to usable R version string
-  splat <- strsplit(versionLine, "\\s+", perl = TRUE)[[1]]
+  splatVersion <- if (grepl("openjdk version", versionLine)) {
+    strsplit(versionLine, "\"")[[1]][[2]]
+  } else {
+    splat <- strsplit(versionLine, "\\s+", perl = TRUE)[[1]]
+    splat[grepl("9|[0-9]+\\.[0-9]+\\.[0-9]+", splat)]
+  }
 
-  splatVersion <- splat[grepl("9|[0-9]+\\.[0-9]+\\.[0-9]+", splat)]
   if (length(splatVersion) != 1)
     stop("Java version detected but couldn't parse version from: ", versionLine)
 

--- a/R/java.R
+++ b/R/java.R
@@ -45,7 +45,11 @@ validate_java_version <- function(master, spark_home) {
 
   # query its version
   version <- system2(java, "-version", stderr = TRUE, stdout = TRUE)
-  validate_java_version_line(master, version)
+  java_version <- validate_java_version_line(master, version)
+
+  spark_version <- spark_version_from_home(spark_home)
+  if (compareVersion(java_version, "11") >= 0 && compareVersion(spark_version, "3.0.0") < 0)
+    stop("Java 11 is only supported for Spark 3.0.0+", call. = FALSE)
 
   TRUE
 }
@@ -105,4 +109,6 @@ validate_java_version_line <- function(master, version) {
       "and manually configure Spark. Please consider uninstalling Java 9 and reinstalling Java 8. ",
       "To override this failure set 'options(sparklyr.java9 = TRUE)'.")
   }
+
+  parsedVersion
 }


### PR DESCRIPTION
- Add support for JDK11 in Spark 3
- Add informative error message when attempting to use JDK11 with Spark 2 (manually tested only)
- Add `openjdk11` to test matrix

Closes https://github.com/sparklyr/sparklyr/issues/1922, closes https://github.com/sparklyr/sparklyr/issues/2049.