### PR TITLE
fix row.names

### DIFF
--- a/R/sdf_interface.R
+++ b/R/sdf_interface.R
@@ -68,7 +68,7 @@ sdf_prepare_dataframe <- function(x) {
   as.data.frame(
     x,
     stringsAsFactors = FALSE,
-    row.names = FALSE,
+    row.names = NULL,
     optional = TRUE
   )
 }


### PR DESCRIPTION
This fixes the "row names must be 'character' or 'integer', not 'logical'" error I ran into recently in R 3.2.5