### PR TITLE
report doSpark number of workers

### DIFF
--- a/R/do_spark.R
+++ b/R/do_spark.R
@@ -122,6 +122,16 @@ registerDoSpark <- function(spark_conn, ...) {
     switch(item,
       name = pkgName,
       version = packageDescription(pkgName, fields = "Version"),
+      workers = tryCatch(
+        {
+          spark_conf<-invoke(data$spark_conn$state$spark_context, "getConf")
+          # return an integer value greater than 1 as number of workers if
+          # "spark.executor.instances" is not set
+          invoke(spark_conf, "getInt", "spark.executor.instances", as.integer(2))
+        },
+        # return 0 as number of workers if there is an exception
+        error = function(e) { 0 }
+      ),
       NULL
     )
   }

--- a/tests/testthat/test-do-spark.R
+++ b/tests/testthat/test-do-spark.R
@@ -20,6 +20,10 @@ register_test_spark_connection()
   expect_equal(res$do, res$dopar)
 }
 
+test_that("num workers greater than 1", {
+  expect_gt(foreach::getDoParWorkers(), 1)
+})
+
 test_that("doSpark works for simple loop", {
   foreach(x = 1:10) %test% quote(x * x)
 })


### PR DESCRIPTION
doSpark must report it has more than 1 workers for `tune` to consider it as a valid parallel backend