### PR TITLE
make do_spark workers load required packages

### DIFF
--- a/R/do_spark.R
+++ b/R/do_spark.R
@@ -50,6 +50,7 @@ registerDoSpark <- function(spark_conn, ...) {
 
   # internal function called by foreach
   .doSpark <- function(obj, expr, envir, data) {
+    obj$packages <- unique(c(obj$packages, (.packages())))
     # internal function to compile an expression if possible
     .compile <- function(expr, ...) {
       if (getRversion() < "2.13.0" || isTRUE(.globals$do_spark$options$nocompile))
@@ -69,6 +70,10 @@ registerDoSpark <- function(spark_conn, ...) {
 
     # internal function to process spark data frames
     .process_spark_items <- function(...) {
+      # load necessary packages
+      for (p in obj$packages)
+        library(p, character.only=TRUE)
+
       f <- function(item) {
         # NOTE: if `expr` involves any object outside of its own environment then this current
         # implementation will *attempt* to serialize and send those object(s) to Spark workers

--- a/tests/testthat/test-do-spark.R
+++ b/tests/testthat/test-do-spark.R
@@ -20,6 +20,12 @@ register_test_spark_connection()
   expect_equal(res$do, res$dopar)
 }
 
+test_that("doSpark loads required packages", {
+  foreach(x = 1:10) %dopar% {
+    expect_true("testthat" %in% (.packages()))
+  }
+})
+
 test_that("doSpark works for simple loop", {
   foreach(x = 1:10) %test% quote(x * x)
 })


### PR DESCRIPTION
Each worker still needs to load packages that were present in the parent env