### PR TITLE
make doSpark preserve error condition object

### DIFF
--- a/tests/testthat/test-do-spark.R
+++ b/tests/testthat/test-do-spark.R
@@ -20,6 +20,15 @@ register_test_spark_connection()
   expect_equal(res$do, res$dopar)
 }
 
+test_that("doSpark preserves exception error message", {
+  expect_error(
+    foreach (x = 1:10) %dopar% {
+      if (x == 10) stop("runtime error")
+    },
+    regexp = "task 10 failed - \"runtime error\""
+  )
+})
+
 test_that("doSpark works for simple loop", {
   foreach(x = 1:10) %test% quote(x * x)
 })


### PR DESCRIPTION
Rather than reporting the long "Rscript failed ..." error message from user-generated exception in `expr`, doSpark should make worker serialize any error condition object, and then deserialize it back and return error to user, because preserving the exception will make debugging much easier.