### PR TITLE
make doSpark preserve error condition object from worker

### DIFF
--- a/R/do_spark.R
+++ b/R/do_spark.R
@@ -88,12 +88,19 @@ registerDoSpark <- function(spark_conn, ...) {
         }
         # `enclos` now contains a snapshot of all external variables and functions
         # needed for evaluating `expr`
-        res <- eval(
-          expr,
-          envir = as.list(.decode_item(item$encoded)),
-          enclos = enclos
-        )
-        .encode_item(res)
+	tryCatch(
+         {
+            res <- eval(
+              expr,
+              envir = as.list(.decode_item(item$encoded)),
+              enclos = enclos
+            )
+            .encode_item(res)
+	  },
+	  error = function(ex) {
+            .encode_item(ex)
+	  }
+	)
       }
       encoded_res <- sdf_collect(spark_items %>% spark_apply(f, ...))[[1]]
       lapply(encoded_res, .decode_item)

--- a/tests/testthat/test-do-spark.R
+++ b/tests/testthat/test-do-spark.R
@@ -40,6 +40,15 @@ fn_4 <- fn_3(1357)
   expect_equal(res$do, res$dopar)
 }
 
+test_that("doSpark preserves exception error message", {
+  expect_error(
+    foreach (x = 1:10) %dopar% {
+      if (x == 10) stop("runtime error")
+    },
+    regexp = "task 10 failed - \"runtime error\""
+  )
+})
+
 test_that("doSpark works for simple loop", {
   foreach(x = 1:10) %test% quote(x * x)
 })


### PR DESCRIPTION
Rather than wrapping any error from `expr` in the long "Rscript failed ..." error message, doSpark should make worker serialize any error condition object, and then deserialize it back and return error to user, because preserving the error message will make debugging much easier.

