### PR TITLE
WIP: Support for copy_to() in databricks connection

### DIFF
--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -202,11 +202,8 @@ spark_connect <- function(master,
                                spark_master_is_yarn_cluster(master, config)),
                              extensions = extensions,
                              batch = NULL)
-    if (method == "qubole") {
-      scon$method <- "qubole"
-    }
-    if (method == "databricks-connect") {
-      scon$method <- "databricks-connect"
+    if (method != "shell") {
+      scon$method <- method
     }
   } else if (method == "livy") {
     scon <- livy_connection(master = master,
@@ -347,7 +344,7 @@ spark_log_file <- function(sc) {
 
 # TRUE if the Spark Connection is a local install
 spark_connection_is_local <- function(sc) {
-  spark_master_is_local(sc$master)
+  spark_master_is_local(sc$master) && !identical(sc$method, "databricks-connect")
 }
 
 spark_master_is_local <- function(master) {

--- a/R/data_copy.R
+++ b/R/data_copy.R
@@ -205,8 +205,7 @@ spark_data_copy <- function(
     stop("The repartition parameter must be an integer")
   }
 
-  # TODO: @Loquats, @falaki consider moving sc$method == "databricks-connect" check into spark_connection_is_local
-  if ((!spark_connection_is_local(sc) || sc$method == "databricks-connect") && identical(serializer, "csv_file")) {
+  if (!spark_connection_is_local(sc) && identical(serializer, "csv_file")) {
     stop("Using a local file to copy data is not supported for remote clusters")
   }
 

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -23,9 +23,7 @@ shell_connection <- function(master,
   # trigger deprecated warnings
   config <- shell_connection_validate_config(config)
 
-  # TODO: @Loquats, @falaki consider moving method != "databricks-connect" check into spark_master_is_local
-  # for local mode we support SPARK_HOME via locally installed versions and version overrides SPARK_HOME
-  if (spark_master_is_local(master) && method != "databricks-connect") {
+  if (spark_master_is_local(master)) {
     if (!nzchar(spark_home) || !is.null(version)) {
       installInfo <- spark_install_find(version, hadoop_version, latest = FALSE, hint = TRUE)
       spark_home <- installInfo$sparkVersionDir


### PR DESCRIPTION
Currently, `copy_to()` does not work with `spark_connect(master = "local", method = "databricks")`, spotted by @blairj09.

The problem is that [the selection of the data serializer](https://github.com/sparklyr/sparklyr/blob/cf3f4d6e5f56856aa4f25fe887190c11b2090c8a/R/data_copy.R#L227) currently assumes the databricks connection runs in the driver node, which is not the case. Moving the check for `databrick-connect` to `spark_connection_is_local()` fixes this issue and potentially fixes (or breaks!) other code paths. I took a look at the code and I believe this is the right fix, but we should definitely wait for tests to pass.

Notice also that, in theory, if `arrow` is installed in the databricks cluster, `copy_to()` should work and be so much faster than the standard implementation.