### PR TITLE
adjust test-ml-feature-idf after hashing algorithm change in Spark 3.0.0

### DIFF
--- a/tests/testthat/test-ml-feature-idf.R
+++ b/tests/testthat/test-ml-feature-idf.R
@@ -33,8 +33,18 @@ test_that("ft_idf() works properly", {
     pull(features) %>%
     first()
 
-  expect_equal(which(idf_1 != 0), c(1, 6, 10, 18))
-  expect_equal(idf_1[which(idf_1 != 0)],
-               c(0.693147180559945, 0.693147180559945, 0.287682072451781, 1.38629436111989
-  ), tol = 1e-4)
+  # hashing implementation changed in 3.0 -- https://issues.apache.org/jira/browse/SPARK-23469
+  expected_non_zero_idxes <- ifelse(
+    spark_version(sc) >= "3.0.0",
+    list(c(7, 9, 14, 17)),
+    list(c(1, 6, 10, 18))
+  )
+  expected_res <- ifelse(
+    spark_version(sc) >= "3.0.0",
+    list(c(0.287682072451781, 0.693147180559945, 0.287682072451781, 0.575364144903562)),
+    list(c(0.693147180559945, 0.693147180559945, 0.287682072451781, 1.38629436111989))
+  )
+
+  expect_equal(which(idf_1 != 0), expected_non_zero_idxes[[1]])
+  expect_equal(idf_1[which(idf_1 != 0)], expected_res[[1]], tol = 1e-4)
 })


### PR DESCRIPTION
As pointed out in https://github.com/sparklyr/sparklyr/issues/2187, HashingTF uses a different hashing algorithm in Spark 3.0.0

Signed-off-by: Yitao Li <yitao@rstudio.com>