### PR TITLE
Enabling tests that pass with datbaricks-connect=6.3.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
                     def uuid = UUID.randomUUID().toString()
                     def clusterParams = [
                         cluster_name: "jenkins-${uuid}",
-                        spark_version: "6.2.x-scala2.11",
+                        spark_version: "6.3.x-scala2.11",
                         node_type_id: "i3.xlarge",
                         num_workers: 1,
                         autotermination_minutes: 10,

--- a/tests/testthat/test-barrier.R
+++ b/tests/testthat/test-barrier.R
@@ -1,5 +1,6 @@
 context("barrier")
 
+skip_databricks_connect()
 test_that("barrier-spark_apply works", {
   test_requires_version("2.4.0")
   sc <- testthat_spark_connection()

--- a/tests/testthat/test-barrier.R
+++ b/tests/testthat/test-barrier.R
@@ -1,6 +1,5 @@
 context("barrier")
 
-skip_databricks_connect()
 test_that("barrier-spark_apply works", {
   test_requires_version("2.4.0")
   sc <- testthat_spark_connection()

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -1,6 +1,5 @@
 context("binds")
 
-skip_databricks_connect()
 test_requires("dplyr")
 sc <- testthat_spark_connection()
 

--- a/tests/testthat/test-copy-to.R
+++ b/tests/testthat/test-copy-to.R
@@ -1,6 +1,5 @@
 context("copy data")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_that("sdf_copy_to works for default serializer", {

--- a/tests/testthat/test-copy-to.R
+++ b/tests/testthat/test-copy-to.R
@@ -25,6 +25,7 @@ test_that("sdf_copy_to works for scala serializer", {
 })
 
 test_that("sdf_copy_to works for csv serializer", {
+  skip_databricks_connect()
   skip_livy()
 
   df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble()

--- a/tests/testthat/test-do-spark.R
+++ b/tests/testthat/test-do-spark.R
@@ -1,6 +1,5 @@
 context("do-spark")
 
-skip_databricks_connect()
 test_requires("foreach")
 test_requires("iterators")
 test_requires("base64enc")

--- a/tests/testthat/test-dplyr-hive-operators.R
+++ b/tests/testthat/test-dplyr-hive-operators.R
@@ -1,6 +1,5 @@
 context("hive operators")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_that("regex relational operators work", {

--- a/tests/testthat/test-dplyr-join.R
+++ b/tests/testthat/test-dplyr-join.R
@@ -1,6 +1,5 @@
 context("dplyr join")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_that("left_join works as expected", {

--- a/tests/testthat/test-dplyr-lead-lag.R
+++ b/tests/testthat/test-dplyr-lead-lag.R
@@ -1,6 +1,5 @@
 context("lag & lead")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_that("lead and lag take numeric values for 'n' (#925)", {

--- a/tests/testthat/test-dplyr-stats.R
+++ b/tests/testthat/test-dplyr-stats.R
@@ -1,6 +1,5 @@
 context("dplyr stats")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_that("cor, cov, sd and var works as expected", {

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -122,6 +122,7 @@ test_that("'sample_n' and 'sample_frac' work in nontrivial queries (#1299)", {
 })
 
 test_that("'sdf_broadcast' forces broadcast hash join", {
+  skip_databricks_connect()
   query_plan <- df1_tbl %>%
     sdf_broadcast() %>%
     left_join(df2_tbl, by = "b") %>%

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -1,6 +1,5 @@
 context("dplyr")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 iris_tbl <- testthat_tbl("iris")

--- a/tests/testthat/test-partitioning.R
+++ b/tests/testthat/test-partitioning.R
@@ -10,6 +10,8 @@ test_that("sdf_repartition works", {
 })
 
 test_that("sdf_reparition: partitioning by column works", {
+
+  skip_databricks_connect()
   test_requires_version("2.0.0", "partitioning by column requires spark 2.0+")
   iris_tbl <- testthat_tbl("iris")
   expect_match(iris_tbl %>%

--- a/tests/testthat/test-partitioning.R
+++ b/tests/testthat/test-partitioning.R
@@ -1,6 +1,5 @@
 context("partitioning")
 
-skip_databricks_connect()
 test_that("sdf_repartition works", {
   iris_tbl <- testthat_tbl("iris")
 

--- a/tests/testthat/test-pivot.R
+++ b/tests/testthat/test-pivot.R
@@ -1,6 +1,5 @@
 context("pivot")
 
-skip_databricks_connect()
 test_requires("dplyr", "ggplot2")
 
 sc <- testthat_spark_connection()

--- a/tests/testthat/test-read-write-multiple.R
+++ b/tests/testthat/test-read-write-multiple.R
@@ -1,6 +1,5 @@
 context("read-write-multiple")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_readwrite <- function(sc, writer, reader, name = "testtable", ...) {

--- a/tests/testthat/test-read-write-multiple.R
+++ b/tests/testthat/test-read-write-multiple.R
@@ -2,6 +2,7 @@ context("read-write-multiple")
 
 sc <- testthat_spark_connection()
 
+skip_databricks_connect()
 test_readwrite <- function(sc, writer, reader, name = "testtable", ...) {
   path <- file.path(dirname(sc$output_file), c("batch_1", "batch_2"))
   path_glob <- file.path(dirname(sc$output_file), "batch*")

--- a/tests/testthat/test-read-write.R
+++ b/tests/testthat/test-read-write.R
@@ -1,6 +1,5 @@
 context("read-write")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_that("spark_read_csv() succeeds when column contains similar non-ascii", {

--- a/tests/testthat/test-read-write.R
+++ b/tests/testthat/test-read-write.R
@@ -2,6 +2,7 @@ context("read-write")
 
 sc <- testthat_spark_connection()
 
+skip_databricks_connect()
 test_that("spark_read_csv() succeeds when column contains similar non-ascii", {
   if (.Platform$OS.type == "windows")
     skip("CSV encoding is slightly different in windows")

--- a/tests/testthat/test-sdf-collect.R
+++ b/tests/testthat/test-sdf-collect.R
@@ -1,6 +1,5 @@
 context("describe")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_that("sdf_collect() works properly", {

--- a/tests/testthat/test-sdf-describe.R
+++ b/tests/testthat/test-sdf-describe.R
@@ -1,6 +1,5 @@
 context("describe")
 
-skip_databricks_connect()
 test_requires("dplyr")
 
 sc <- testthat_spark_connection()

--- a/tests/testthat/test-sdf-drop-duplicates.R
+++ b/tests/testthat/test-sdf-drop-duplicates.R
@@ -1,6 +1,5 @@
 context("drop-duplicates")
 
-skip_databricks_connect()
 test_requires("dplyr")
 
 sc <- testthat_spark_connection()

--- a/tests/testthat/test-sdf-stat.R
+++ b/tests/testthat/test-sdf-stat.R
@@ -1,6 +1,5 @@
 context("sdf stat")
 
-skip_databricks_connect()
 test_that("sdf_crosstab() works", {
   sc <- testthat_spark_connection()
   mtcars_tbl <- testthat_tbl("mtcars")

--- a/tests/testthat/test-spark-apply-bundle.R
+++ b/tests/testthat/test-spark-apply-bundle.R
@@ -1,6 +1,5 @@
 context("spark apply bundle")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_that("'spark_apply_bundle' can `worker_spark_apply_unbundle`", {

--- a/tests/testthat/test-spark-apply-ext.R
+++ b/tests/testthat/test-spark-apply-ext.R
@@ -1,6 +1,5 @@
 context("spark apply")
 
-skip_databricks_connect()
 test_requires("dplyr")
 sc <- testthat_spark_connection()
 

--- a/tests/testthat/test-spark-apply.R
+++ b/tests/testthat/test-spark-apply.R
@@ -1,6 +1,5 @@
 context("spark apply")
 
-skip_databricks_connect()
 test_requires("dplyr")
 sc <- testthat_spark_connection()
 


### PR DESCRIPTION
This patch enables the following additional tests that now pass with `databricks-connect==6.3.1`:

* test-barrier.R
* test-binds.R
* test-copy-to.R
* test-do-spark.R
* test-dplyr-hive-operators.R
* test-dplyr-join.R
* test-dplyr-lead-lag.R
* test-dplyr-stats.R
* test-dplyr.R
* test-pivot.R
* test-sdf-collect.R
* test-sdf-describe.R
* test-sdf-drop-duplicates.R
* test-sdf-stat.R
* test-spark-apply-bundle.R
* test-spark-apply-ext.R
* test-spark-apply.R
* test-partitioning.R