### PR TITLE
fixing the issue I found in https://github.com/sparklyr/sparklyr/issu…

### DIFF
--- a/R/spark_apply.R
+++ b/R/spark_apply.R
@@ -150,6 +150,14 @@ spark_apply <- function(x,
                         ...) {
   memory <- force(memory)
   args <- list(...)
+  # If columns is of the form c("col_name1", "col_name2", ...)
+  # then leave it as-is
+  # Otherwise if it is of the form c(col_name1 = "col_type1", ...)
+  # or list(col_name1 = "col_type1", ...), etc, then make sure it gets coerced
+  # into a list instead of a character vector with names
+  if (!identical(names(columns), NULL)) {
+    columns <- as.list(columns)
+  }
   assert_that(is.function(f) || is.raw(f) || is.language(f))
   if (is.language(f)) f <- rlang::as_closure(f)
 

--- a/tests/testthat/test-spark-apply.R
+++ b/tests/testthat/test-spark-apply.R
@@ -37,3 +37,34 @@ test_that("'spark_apply' works with 'group_by'", {
     }
   )
 })
+
+test_columns_param <- function(cols) {
+  fn <- function(x) {
+    x * x
+  }
+  sdf <- sdf_copy_to(sc, data.frame("x" = c(seq(1.0, 10.0, 1.0))), overwrite = TRUE)
+  res <- spark_apply(sdf, fn, columns = cols) %>% sdf_collect()
+  if (!identical(names(cols), NULL)) {
+    expect_equal(names(res), names(cols))
+    col_name <- names(cols)[[1]]
+  } else {
+    expect_equal(names(res), cols)
+    col_name <- cols[[1]]
+  }
+  expect_equal(nrow(res), 10)
+  for (x in seq(1, 10)) {
+    expect_equal(res[x,][[col_name]], x * x)
+  }
+}
+
+test_that("'spark_apply' works with columns param of type vector", {
+  test_columns_param(cols = c(result = "double"))
+})
+
+test_that("'spark_apply' works with columns param of type string", {
+  test_columns_param(cols = c("result"))
+})
+
+test_that("'spark_apply' works with columns param of type list", {
+  test_columns_param(cols = list(result = "double"))
+})


### PR DESCRIPTION
I think the bug happened because `is.character(columns)` will evaluate to true for both `columns = c(result = "double")` and `columns = c("result")` and the code path supposedly handling the latter case is also handling the former, causing a column named "double" to be created.

Signed-off-by: Yitao Li <yitao@rstudio.com>