### PR TITLE
probable workaround for windows temp dir issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ environment:
     INSTALL_WINUTILS: true
     R_VERSION: release
     USE_RTOOLS: true
+    TEMP: "C:\\Users\\appveyor"
 
   matrix:
   - SPARK_VERSION: "1.6.3"


### PR DESCRIPTION
The default Windows temp directory could be a dangerous war zone where random processes might nuke permissions or delete files (e.g., https://techcommunity.microsoft.com/t5/storage-at-microsoft/windows-10-and-storage-sense/ba-p/428270 or similar) -- So, moving the temp directory for test environment to a different user-writable directory, which fixes the spark shell log unreadable issue in #2292

Signed-off-by: Yitao Li <yitao@rstudio.com>