### PR TITLE
delete skip_on_spark_master() calls in most tests

### DIFF
--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -172,7 +172,6 @@ test_that("'sdf_bind_rows' err for non-tbl_spark", {
 test_that("'sdf_bind_rows' handles column type upcasting (#804)", {
   # Need support for NaN ARROW-3615
   skip_on_arrow()
-  skip_on_spark_master()
 
   test_requires("dplyr")
 

--- a/tests/testthat/test-broom-naive_bayes.R
+++ b/tests/testthat/test-broom-naive_bayes.R
@@ -4,7 +4,6 @@ skip_databricks_connect()
 library(dplyr)
 
 test_that("naive_bayes.tidy() works", {
-  skip_on_spark_master()
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")
   iris_tbl <- testthat_tbl("iris")

--- a/tests/testthat/test-dplyr-lead-lag.R
+++ b/tests/testthat/test-dplyr-lead-lag.R
@@ -3,7 +3,6 @@ context("lag & lead")
 sc <- testthat_spark_connection()
 
 test_that("lead and lag take numeric values for 'n' (#925)", {
-  skip_on_spark_master()
   test_requires("dplyr")
   example_df <- data_frame(ID = 1:10, Cat = rep(letters[1:5], 2),
                           Numb = c(3, 10, NA, 5, 1, 6, NA, 4, NA, 8))

--- a/tests/testthat/test-kubernetes-config.R
+++ b/tests/testthat/test-kubernetes-config.R
@@ -1,7 +1,6 @@
 context("kubernetes config")
 
 test_that("spark_kubernetes_config can generate correct config", {
-  skip_on_spark_master()
   expect_equal(
     spark_config_kubernetes("k8s://https://192.168.99.100:8443", driver = "spark-driver",
                             forward = FALSE, fix_config = FALSE),

--- a/tests/testthat/test-ml-classification-naive-bayes.R
+++ b/tests/testthat/test-ml-classification-naive-bayes.R
@@ -46,7 +46,6 @@ test_that("ml_naive_bayes() works properly", {
 })
 
 test_that("ml_naive_bayes() and e1071::naiveBayes produce similar results", {
-  skip_on_spark_master()
   sc <- testthat_spark_connection()
   test_requires("e1071", "mlbench")
 
@@ -76,7 +75,6 @@ test_that("ml_naive_bayes() and e1071::naiveBayes produce similar results", {
 })
 
 test_that("ml_naive_bayes() print outputs are correct", {
-  skip_on_spark_master()
   sc <- testthat_spark_connection()
   iris_tbl <- testthat_tbl("iris")
   m <- ml_naive_bayes(iris_tbl, Species ~ Petal_Width + Petal_Length)

--- a/tests/testthat/test-ml-feature-idf.R
+++ b/tests/testthat/test-ml-feature-idf.R
@@ -20,7 +20,6 @@ test_that("ft_idf() param setting", {
 
 test_that("ft_idf() works properly", {
   test_requires_version("2.0.0", "hashing implementation changed in 2.0 -- https://issues.apache.org/jira/browse/SPARK-10574")
-  skip_on_spark_master()
   sc <- testthat_spark_connection()
   sentence_df <- data.frame(
     sentence = c("Hi I heard about Spark",

--- a/tests/testthat/test-ml-feature-imputer.R
+++ b/tests/testthat/test-ml-feature-imputer.R
@@ -20,7 +20,6 @@ test_that("ft_imputer() param setting", {
 })
 
 test_that("ft_imputer() works properly", {
-  skip_on_spark_master()
   sc <- testthat_spark_connection()
   test_requires_version("2.2.0", "imputer requires Spark 2.2.0+")
   df <- data.frame(id = 1:5, V1 = c(1, 2, NA, 4, 5))

--- a/tests/testthat/test-ml-feature-r-formula.R
+++ b/tests/testthat/test-ml-feature-r-formula.R
@@ -17,7 +17,6 @@ test_that("ft_r_formula() param setting", {
 })
 
 test_that("r formula works as expected", {
-  skip_on_spark_master()
   sc <- testthat_spark_connection()
   iris_tbl <- testthat_tbl("iris")
   pipeline <- ml_pipeline(sc) %>%

--- a/tests/testthat/test-ml-feature-word2vec.R
+++ b/tests/testthat/test-ml-feature-word2vec.R
@@ -43,7 +43,6 @@ test_that("ft_word2vec() returns result with correct length", {
 test_that("ml_find_synonyms works properly", {
   # NOTE: this test case is functionally identical to the one in
   # https://github.com/apache/spark/blob/87b93d32a6bfb0f2127019b97b3fc1d13e16a10b/mllib/src/test/scala/org/apache/spark/mllib/feature/Word2VecSuite.scala#L37
-  skip_on_spark_master()
   test_requires_version("2.0.0", "spark computation different in 1.6.x")
   sc <- testthat_spark_connection()
   sentence <- data.frame(sentence = do.call(paste, as.list(c(rep("a b", 100), rep("a c", 10)))))

--- a/tests/testthat/test-spark-apply-ext.R
+++ b/tests/testthat/test-spark-apply-ext.R
@@ -180,7 +180,6 @@ test_that("'spark_apply' can roundtrip Date-Time", {
 
 test_that("'spark_apply' supports grouped empty results", {
   skip_slow("takes too long to measure coverage")
-  skip_on_spark_master()
   process_data <- function(DF, exclude) {
     DF <- subset(DF, select = colnames(DF)[!colnames(DF) %in% exclude])
     DF[complete.cases(DF),]


### PR DESCRIPTION
I think by now we can delete a number of the `skip_on_spark_master()` calls, if not all of them