### PR TITLE
Fix unit tests that attempt to create tables that already exist

### DIFF
--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -382,3 +382,7 @@ skip_databricks_connect <- function() {
   if (Sys.getenv("TEST_DATABRICKS_CONNECT") == "true")
     skip("Test is skipped on Databricks Connect")
 }
+
+random_table_name <- function(prefix) {
+  paste0(prefix, paste0(floor(runif(10, 0, 10)), collapse = ""))
+}

--- a/tests/testthat/test-dbi.R
+++ b/tests/testthat/test-dbi.R
@@ -1,28 +1,30 @@
 context("dbi")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 iris_tbl <- testthat_tbl("iris")
 dbi_df <- data.frame(a = 1:3, b = letters[1:3])
+
+psersited_table_name <- random_table_name("persisted_")
+temp_table_name <- random_table_name("temporary_")
 
 test_that("dbWriteTable can write a table", {
   if (spark_version(sc) < "2.2.0") skip("tables not supported before 2.0.0")
 
   test_requires("DBI")
 
-  dbWriteTable(sc, "dbi_persists", dbi_df)
-  dbWriteTable(sc, "dbi_temporary", dbi_df, temporary = TRUE)
+  dbWriteTable(sc, psersited_table_name, dbi_df)
+  dbWriteTable(sc, temp_table_name, dbi_df, temporary = TRUE)
 
   tables <- dbGetQuery(sc, "SHOW TABLES")
 
   expect_equal(
-    tables[tables$tableName == "dbi_persists", ]$isTemporary,
+    tables[tables$tableName == psersited_table_name, ]$isTemporary,
     FALSE
   )
 
   expect_equal(
-    tables[tables$tableName == "dbi_temporary", ]$isTemporary,
+    tables[tables$tableName == temp_table_name, ]$isTemporary,
     TRUE
   )
 })
@@ -33,4 +35,9 @@ test_that("dbGetQuery works with parameterized queries", {
 
   virginica <- dbGetQuery(sc, "SELECT * FROM iris WHERE species = ?virginica", virginica = "virginica")
   expect_equal(nrow(virginica), 50)
+})
+
+teardown({
+  dbRemoveTable(sc, persisted_table_name)
+  dbRemoveTable(sc, temp_table_name)
 })

--- a/tests/testthat/test-dplyr-join.R
+++ b/tests/testthat/test-dplyr-join.R
@@ -9,8 +9,8 @@ test_that("left_join works as expected", {
   s1 <- data.frame(x=1:3, y=4:6)
   s2 <- data.frame(x=1:3, y=7:9)
 
-  d1 <- copy_to(sc, s1)
-  d2 <- copy_to(sc, s2)
+  d1 <- copy_to(sc, s1, overwrite = TRUE)
+  d2 <- copy_to(sc, s2, overwrite = TRUE)
 
   j1 <- left_join(d1, d2, by='x') %>% collect()
   j2 <- left_join(s1, s2, by='x')

--- a/tests/testthat/test-ml-feature-random-projection-lsh.R
+++ b/tests/testthat/test-ml-feature-random-projection-lsh.R
@@ -1,5 +1,6 @@
 context("ml feature bucketed random projection lsh")
 
+skip_databricks_connect()
 test_that("ft_bucketed_random_projection_lsh() default params", {
   test_requires_latest_spark()
   sc <- testthat_spark_connection()

--- a/tests/testthat/test-ml-feature-random-projection-lsh.R
+++ b/tests/testthat/test-ml-feature-random-projection-lsh.R
@@ -1,6 +1,5 @@
 context("ml feature bucketed random projection lsh")
 
-skip_databricks_connect()
 test_that("ft_bucketed_random_projection_lsh() default params", {
   test_requires_latest_spark()
   sc <- testthat_spark_connection()

--- a/tests/testthat/test-read-write.R
+++ b/tests/testthat/test-read-write.R
@@ -1,9 +1,10 @@
 context("read-write")
 
 sc <- testthat_spark_connection()
+iris_table_name <- random_table_name("iris")
 
-skip_databricks_connect()
 test_that("spark_read_csv() succeeds when column contains similar non-ascii", {
+  skip_databricks_connect()
   if (.Platform$OS.type == "windows")
     skip("CSV encoding is slightly different in windows")
 
@@ -22,6 +23,7 @@ test_that("spark_read_csv() succeeds when column contains similar non-ascii", {
 })
 
 test_that("spark_read_json() can load data using column names", {
+  skip_databricks_connect()
   json <- file("test.json", "w+")
   cat("{\"Sepal_Length\":5.1,\"Species\":\"setosa\", \"Other\": { \"a\": 1, \"b\": \"x\"}}\n", file = json)
   cat("{\"Sepal_Length\":4.9,\"Species\":\"setosa\", \"Other\": { \"a\": 2, \"b\": \"y\"}}\n", file = json)
@@ -40,6 +42,7 @@ test_that("spark_read_json() can load data using column names", {
 })
 
 test_that("spark_read_json() can load data using column types", {
+  skip_databricks_connect()
   test_requires("dplyr")
 
   json <- file("test.json", "w+")
@@ -62,6 +65,7 @@ test_that("spark_read_json() can load data using column types", {
 })
 
 test_that("spark_read_csv() can read long decimals", {
+  skip_databricks_connect()
   csv <- file("test.csv", "w+")
   cat("decimal\n1\n12312312312312300000000000000", file = csv)
   close(csv)
@@ -78,6 +82,7 @@ test_that("spark_read_csv() can read long decimals", {
 })
 
 test_that("spark_read_text() and spark_write_text() read and write basic files", {
+  skip_databricks_connect()
   test_requires("dplyr")
 
   text_file <- file("test.txt", "w+")
@@ -114,20 +119,21 @@ test_that("spark_write_table() can append data", {
 
   iris_tbl <- testthat_tbl("iris")
 
-  spark_write_table(iris_tbl, "iris_append_tbl")
+  spark_write_table(iris_tbl, iris_table_name)
   expect_equal(
-    sdf_nrow(tbl(sc, "iris_append_tbl")),
+    sdf_nrow(tbl(sc, iris_table_name)),
     nrow(iris)
   )
 
-  spark_write_table(iris_tbl, "iris_append_tbl", mode = "append")
+  spark_write_table(iris_tbl, iris_table_name, mode = "append")
   expect_equal(
-    sdf_nrow(tbl(sc, "iris_append_tbl")),
+    sdf_nrow(tbl(sc, iris_table_name)),
     2 * nrow(iris)
   )
 })
 
 test_that("spark_write_table() can write data", {
+  skip_databricks_connect()
   if (spark_version(sc) < "2.0.0") skip("tables not supported before 2.0.0")
   test_requires("dplyr")
 
@@ -141,6 +147,7 @@ test_that("spark_write_table() can write data", {
 })
 
 test_that("spark_read_csv() can rename columns", {
+  skip_databricks_connect()
   csv <- file("test.csv", "w+")
   cat("a,b,c\n1,2,3", file = csv)
   close(csv)
@@ -156,6 +163,7 @@ test_that("spark_read_csv() can rename columns", {
 })
 
 test_that("spark_read_text() can read a whole file", {
+  skip_databricks_connect()
   test_requires("dplyr")
 
   text_file <- file("test.txt", "w+")
@@ -171,6 +179,7 @@ test_that("spark_read_text() can read a whole file", {
 })
 
 test_that("spark_read_csv() can read with no name", {
+  skip_databricks_connect()
   test_requires("dplyr")
 
   text_file <- file("test.csv", "w+")
@@ -185,6 +194,7 @@ test_that("spark_read_csv() can read with no name", {
 })
 
 test_that("spark_read_csv() can read with named character name", {
+  skip_databricks_connect()
   test_requires("dplyr")
 
   text_file <- file("test.csv", "w+")
@@ -197,6 +207,7 @@ test_that("spark_read_csv() can read with named character name", {
 
 
 test_that("spark_read_csv() can read column types", {
+  skip_databricks_connect()
   csv <- file("test.csv", "w+")
   cat("a,b,c\n1,2,3", file = csv)
   close(csv)
@@ -220,6 +231,7 @@ test_that("spark_read_csv() can read column types", {
 })
 
 test_that("spark_read_csv() can read verbatim column types", {
+  skip_databricks_connect()
   csv <- file("test.csv", "w+")
   cat("a,b,c\n1,2,3", file = csv)
   close(csv)
@@ -241,4 +253,8 @@ test_that("spark_read_csv() can read verbatim column types", {
     )
   )
 
+})
+
+teardown({
+  db_drop_table(iris_table_name)
 })

--- a/tests/testthat/test-serialization.R
+++ b/tests/testthat/test-serialization.R
@@ -1,6 +1,5 @@
 context("serialization")
 
-skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_requires("nycflights13")
@@ -72,6 +71,7 @@ test_that("data.frames with '|' can be copied", {
 
 test_that("data.frames with many columns survive roundtrip", {
   skip_slow("takes too long to measure coverage")
+  skip_databricks_connect()
 
   n <- 1E3
   data <- as.data.frame(replicate(n, 1L, simplify = FALSE))
@@ -81,6 +81,7 @@ test_that("data.frames with many columns survive roundtrip", {
 })
 
 test_that("data.frames with many columns don't cause Java StackOverflows", {
+  skip_databricks_connect()
   version <- Sys.getenv("SPARK_VERSION", unset = "2.2.0")
 
   n <- if (version >= "2.0.0") 500 else 5000
@@ -92,6 +93,7 @@ test_that("data.frames with many columns don't cause Java StackOverflows", {
 })
 
 test_that("'ml_predict()', 'predict()' return same results", {
+  skip_databricks_connect()
   test_requires("dplyr")
 
   model <- flights_tbl %>%
@@ -127,6 +129,7 @@ test_that("copy_to() succeeds when last column contains missing / empty values",
 })
 
 test_that("collect() can retrieve all data types correctly", {
+  skip_databricks_connect()
   # https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types#LanguageManualTypes
   library(dplyr)
 
@@ -351,6 +354,7 @@ test_that("environments are sent to Scala Maps (#1058)", {
 })
 
 test_that("collect() can retrieve nested list efficiently", {
+  skip_databricks_connect()
   if (spark_version(sc) < "2.0.0") skip("performance improvement not available")
 
   temp_json <- tempfile(fileext = ".json")


### PR DESCRIPTION
- Randomize table names
- Clean up tables after each suite.

Fixes https://github.com/sparklyr/sparklyr/issues/2307