### PR TITLE
make spark_submit work for spark 3.0.0-preview / master

### DIFF
--- a/tests/testthat/test-submit.R
+++ b/tests/testthat/test-submit.R
@@ -2,7 +2,6 @@ context("submit")
 
 skip_databricks_connect()
 test_that("spark_submit() can submit batch jobs", {
-  skip_on_spark_master()
   if (.Platform$OS.type == "windows")
     skip("spark_submit() not yet implemented for windows")
 


### PR DESCRIPTION
2nd attempt at fixing the issue in https://github.com/sparklyr/sparklyr/issues/2193

I think the problem was in spark_submit use case in absence of `sc$home_version` or `spark_version(sc)`, there was no way to know which version of Spark is running until a `SparkContext` object is returned from the shell connection, so when that happens there needs to be another code path checking for Spark version >= 2.0 and then initialize Hive context accordingly.