### PR TITLE
fix a minor bug in spark dataframe's print method

### DIFF
--- a/R/dplyr_spark_table.R
+++ b/R/dplyr_spark_table.R
@@ -92,6 +92,10 @@ print.tbl_spark <- function(x, ...) {
   }
 
   rows <- getOption("tibble.print_min", getOption("dplyr.print_min", 10))
+  options <- list(...)
+  if ("n" %in% names(options)) {
+    rows <- max(rows, options$n)
+  }
 
   grps <- dbplyr::op_grps(x$ops)
   sort <- dbplyr::op_sort(x$ops) %>%
@@ -128,5 +132,5 @@ print.tbl_spark <- function(x, ...) {
   data <- tibble::as_tibble(as.data.frame(data))
   class(data) <- c("tbl_spark_print", class(data))
 
-  print(data)
+  print(data, ...)
 }

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -15,3 +15,20 @@ test_that("print supports spark tables", {
 
   expect_true(grepl("with more rows", printed[14]))
 })
+
+test_that("can print more than 10 rows from a spark tables", {
+  printed <- capture.output(sdf_len(sc, 100) %>% print(n = 50))
+
+  expect_equal(
+    printed[1:2],
+    c(
+      "# Source: spark<?> [?? x 1]",
+      "      id"
+    )
+  )
+
+  expect_true(grepl("1", printed[4]))
+  expect_true(grepl("49", printed[52]))
+  expect_true(grepl("50", printed[53]))
+  expect_true(grepl("with more rows", printed[54]))
+})


### PR DESCRIPTION
As observed in https://github.com/sparklyr/sparklyr/issues/2258, `sdf_len(sc, 100) %>% print(n = 20)` should return 20 rows not 10. Would be good to get this fixed because sometimes this impedes my debugging workflow as well.

Signed-off-by: Yitao Li <yitao@rstudio.com>