### PR TITLE
Add local property for Databricks Connect

### DIFF
--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -274,6 +274,10 @@ spark_connect <- function(master,
     }
   }, onexit = TRUE)
 
+  if (method == "databricks-connect") {
+    spark_context(scon) %>% invoke("setLocalProperty", "spark.databricks.service.client.type", "sparklyr")
+  }
+
   # add to our internal list
   spark_connections_add(scon)
 

--- a/tests/testthat/test-databricks-connect.R
+++ b/tests/testthat/test-databricks-connect.R
@@ -21,3 +21,10 @@ test_that("csv_file is disabled when using databricks-connect", {
     }
   )
 })
+
+test_that("spark local property is set", {
+  sc <- testthat_spark_connection()
+
+  client_type = spark_context(sc) %>% invoke("getLocalProperty", "spark.databricks.service.client.type")
+  expect_equal(client_type, "sparklyr")
+})


### PR DESCRIPTION
This will allow DB Connect to identify whether it is being called from sparklyr (as opposed to sparkr, pyspark, etc.)