### PR TITLE
fix a spark-3.0 compatibility issue when connecting to an existing spark session

### DIFF
--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -566,50 +566,57 @@ shell_connection_config_defaults <- function() {
 
 #' @export
 initialize_connection.spark_shell_connection <- function(sc) {
+  create_spark_config <- function() {
+    # create the spark config
+    conf <- invoke_new(sc, "org.apache.spark.SparkConf")
+    conf <- invoke(conf, "setAppName", sc$app_name)
+
+    if (!spark_master_is_yarn_cluster(sc$master, sc$config) &&
+        !spark_master_is_gateway(sc$master)) {
+      conf <- invoke(conf, "setMaster", sc$master)
+
+      if (!is.null(sc$spark_home))
+        conf <- invoke(conf, "setSparkHome", sc$spark_home)
+    }
+
+    context_config <- connection_config(sc, "spark.", c("spark.sql."))
+    apply_config(conf, context_config, "set", "spark.")
+
+    default_config <- shell_connection_config_defaults()
+    default_config_remove <- Filter(function(e) e %in% names(context_config), names(default_config))
+    default_config[default_config_remove] <- NULL
+    apply_config(conf, default_config, "set", "spark.")
+
+    conf
+  }
+
   # initialize and return the connection
   tryCatch({
     backend <- invoke_static(sc, "sparklyr.Shell", "getBackend")
     sc$state$spark_context <- invoke(backend, "getSparkContext")
 
+    # create the spark config
+    conf <- create_spark_config()
+
+    init_hive_ctx_for_spark_2_plus <- function() {
+      # For Spark 2.0+, we create a `SparkSession`.
+      session <- invoke_static(
+        sc,
+        "org.apache.spark.sql.SparkSession",
+        "builder"
+      ) %>%
+        invoke("config", conf) %>%
+        apply_config(connection_config(sc, "spark.sql."), "config", "spark.sql.") %>%
+        invoke("getOrCreate")
+
+      # Cache the session as the "hive context".
+      sc$state$hive_context <- session
+
+      # Set the `SparkContext`.
+      sc$state$spark_context <- sc$state$spark_context %||% invoke(session, "sparkContext")
+    }
+
     if (is.null(spark_context(sc))) {
-      # create the spark config
-      conf <- invoke_new(sc, "org.apache.spark.SparkConf")
-      conf <- invoke(conf, "setAppName", sc$app_name)
-
-      if (!spark_master_is_yarn_cluster(sc$master, sc$config) &&
-          !spark_master_is_gateway(sc$master)) {
-        conf <- invoke(conf, "setMaster", sc$master)
-
-        if (!is.null(sc$spark_home))
-          conf <- invoke(conf, "setSparkHome", sc$spark_home)
-      }
-
-      context_config <- connection_config(sc, "spark.", c("spark.sql."))
-      apply_config(conf, context_config, "set", "spark.")
-
-      default_config <- shell_connection_config_defaults()
-      default_config_remove <- Filter(function(e) e %in% names(context_config), names(default_config))
-      default_config[default_config_remove] <- NULL
-      apply_config(conf, default_config, "set", "spark.")
-
-      init_hive_ctx_for_spark_2_plus <- function() {
-        # For Spark 2.0+, we create a `SparkSession`.
-        session <- invoke_static(
-          sc,
-          "org.apache.spark.sql.SparkSession",
-          "builder"
-        ) %>%
-          invoke("config", conf) %>%
-          apply_config(connection_config(sc, "spark.sql."), "config", "spark.sql.") %>%
-          invoke("getOrCreate")
-
-        # Cache the session as the "hive context".
-        sc$state$hive_context <- session
-
-        # Set the `SparkContext`.
-        sc$state$spark_context <- sc$state$spark_context %||% invoke(session, "sparkContext")
-      }
-
       # create the spark context and assign the connection to it
       # use spark home version since spark context is not yet initialized in shell connection
       # but spark_home might not be initialized in submit_batch while spark context is available
@@ -639,6 +646,8 @@ initialize_connection.spark_shell_connection <- function(sc) {
       }
 
       invoke(backend, "setSparkContext", spark_context(sc))
+    } else if (is.null(sc$state$hive_context) && spark_version(sc) >= "2.0") {
+      init_hive_ctx_for_spark_2_plus()
     }
 
     # If Spark version is 2.0.0 or above, hive_context should be initialized by now.

--- a/tests/testthat/test-connect-gateway.R
+++ b/tests/testthat/test-connect-gateway.R
@@ -6,3 +6,10 @@ test_that("gateway connection fails with invalid session", {
     spark_connect(master = "sparklyr://localhost:8880/0")
   )
 })
+
+test_that("can connect to an existing session via gateway", {
+  gw <- spark_connect(
+    master = paste0("sparklyr://localhost:8880/", sc$sessionId)
+  )
+  expect_equal(spark_context(gw)$backend, spark_context(sc)$backend)
+})


### PR DESCRIPTION
This PR should fix the issue described in https://github.com/sparklyr/sparklyr/issues/2321

Signed-off-by: Yitao Li <yitao@rstudio.com>