### PR TITLE
use tmpfs to reduce disk IOs in CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 language: r
 dist: trusty
-sudo: false
+sudo: true
 
 branches:
   only:
@@ -128,6 +128,7 @@ matrix:
         - JAVA_VERSION=oraclejdk8
 
 before_install:
+  - sudo mount -t tmpfs tmpfs /tmp
   - if [[ ! -z "$JAVA_VERSION" ]]; then jdk_switcher use $JAVA_VERSION;  fi
   - |
     if [[ ! -z "$JAVA_URL" ]]; then

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -1,6 +1,10 @@
 library(sparklyr)
 library(dplyr)
 
+get_spark_warehouse_dir <- function() {
+  ifelse(.Platform$OS.type == "windows", Sys.getenv("TEMP"), "/tmp")
+}
+
 spark_install_winutils <- function(version) {
   hadoop_version <- if (version < "2.0.0") "2.6" else "2.7"
   spark_dir <- paste("spark-", version, "-bin-hadoop", hadoop_version, sep = "")
@@ -89,6 +93,7 @@ testthat_shell_connection <- function(method = "shell") {
 
     config[["sparklyr.shell.driver-memory"]] <- "3G"
     config[["sparklyr.apply.env.foo"]] <- "env-test"
+    config[["spark.sql.warehouse.dir"]] <- get_spark_warehouse_dir()
 
     sc <- spark_connect(master = "local", method = method, version = version, config = config)
     assign(".testthat_spark_connection", sc, envir = .GlobalEnv)
@@ -240,7 +245,8 @@ testthat_livy_connection <- function() {
       config = list(
         sparklyr.verbose = TRUE,
         sparklyr.connect.timeout = 120,
-        sparklyr.log.invoke = "cat"
+        sparklyr.log.invoke = "cat",
+        spark.sql.warehouse.dir = get_spark_warehouse_dir()
       ),
       version = version,
       sources = TRUE


### PR DESCRIPTION
Update: this turns out to speed up the CI jobs by anywhere between 5-15% -- not as much as I wanted, but still, seems like a good optimization to have. Also, as expected, there was no problem with high memory consumption because the test cases can't really produce that much data to cause such issue.

> but then the CI job will eat up quite a bit more memory I imagine and could potentially run out of
> memory... lemme try it out first and report back what happens


Signed-off-by: Yitao Li <yitao@rstudio.com>