### PR TITLE
[do-not-merge-yet] try running tests without stringi package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ cache:
 
 warnings_are_errors: true
 
-r_github_packages:
-  - gagolews/stringi@v1.4.2
-
 matrix:
   include:
     - name: "Spark 1.6.3 (R 3.2, openjdk7)"


### PR DESCRIPTION
The rcpp dependency from stringi stopped compiling with R 3.2 headers and I can't find a reasonable workaround for that.

We can see which tests would break without stringi (hopefully few to none) and then just skip those tests if R version is 3.2 or below.

Signed-off-by: Yitao Li <yitao@rstudio.com>