### PR TITLE
workaround for Rcpp 1.0.4 compilation failure with R 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ branches:
 cache:
   packages: true
 
-warnings_are_errors: true
-
 r_github_packages:
   - gagolews/stringi@v1.4.2
 
@@ -25,11 +23,13 @@ matrix:
         - JAVA_VERSION=openjdk7
     - name: "Spark 2.2.1 (R oldrel, oraclejdk8)"
       r: oldrel
+      warnings_are_errors: true
       env:
         - SPARK_VERSION="2.2.1"
         - JAVA_VERSION=oraclejdk8
     - name: "Spark 2.3.2 (R release, oraclejdk8)"
       r: release
+      warnings_are_errors: true
       env:
         - SPARK_VERSION="2.3.2"
         - JAVA_VERSION=oraclejdk8
@@ -37,28 +37,33 @@ matrix:
       r: release
       r_packages:
         - glmnet
+      warnings_are_errors: true
       env:
         - SPARK_VERSION="2.4.4"
         - JAVA_VERSION=oraclejdk8
         - CODE_COVERAGE="true"
     - name: "Spark master (R release, oraclejdk8)"
       r: release
+      warnings_are_errors: true
       env:
         - SPARK_VERSION="master"
         - JAVA_VERSION=oraclejdk8
     - name: "Spark master (R release, openjdk11)"
       r: release
+      warnings_are_errors: true
       env:
         - SPARK_VERSION="master"
         - JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
     - name: "Livy 0.5.0 (R release, oraclejdk8, Spark 2.3.0)"
       r: release
+      warnings_are_errors: true
       env:
         - LIVY_VERSION="0.5.0"
         - SPARK_VERSION="2.3.0"
         - JAVA_VERSION=oraclejdk8
     - name: "Arrow 0.11.0 (ref = 'dc5df8f')"
       r: release
+      warnings_are_errors: true
       env:
         - ARROW_ENABLED="true"
         - ARROW_BRANCH="dc5df8f"
@@ -76,6 +81,7 @@ matrix:
     - name: "Arrow 0.13.0 (ref = 'apache-arrow-0.13.0')"
       r: release
       sudo: true
+      warnings_are_errors: true
       env:
         - ARROW_ENABLED="true"
         - ARROW_VERSION="0.13.0"
@@ -86,6 +92,7 @@ matrix:
       r: release
       dist: xenial
       sudo: true
+      warnings_are_errors: true
       env:
         - ARROW_ENABLED="true"
         - ARROW_VERSION="devel"
@@ -97,6 +104,7 @@ matrix:
           packages:
             - openjdk-8-jre
     - name: "Deps Devel (tidyverse, r-lib, forge)"
+      warnings_are_errors: true
       env: R_DEVEL_PACKAGES="true"
       r_github_packages:
         - tidyverse/dplyr
@@ -111,6 +119,7 @@ matrix:
     - r: release
       dist: xenial
       sudo: true
+      warnings_are_errors: true
       env:
         - ARROW_ENABLED="true"
         - ARROW_VERSION="devel"
@@ -122,6 +131,7 @@ matrix:
           packages:
             - openjdk-8-jre
     - r: release
+      warnings_are_errors: true
       env:
         - LIVY_VERSION="0.5.0"
         - SPARK_VERSION="2.3.0"
@@ -139,6 +149,7 @@ before_install:
   - if [[ ! -z "$ARROW_VERSION" ]]; then chmod +x ./ci/arrow-$ARROW_SOURCE.sh ; "./ci/arrow-$ARROW_SOURCE.sh" $ARROW_VERSION; fi
   - if [[ $SPARK_VERSION == "master" ]]; then chmod +x ./ci/spark-master-install.sh ; "./ci/spark-master-install.sh"; fi
   - if [[ $ARROW_ENABLED == "true" ]]; then Rscript ci/.travis.R --arrow $ARROW_BRANCH; fi
+  - if [[ $TRAVIS_R_VERSION =~ ^3\.2.* ]]; then chmod +x ./ci/patch_r_internals_header_file.sh; "./ci/patch_r_internals_header_file.sh"; fi
 
 script:
   - |

--- a/ci/patch_r_internals_header_file.sh
+++ b/ci/patch_r_internals_header_file.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+cd /home/travis/R-bin/lib/R/include
+sudo patch -l << '_PATCH_R_INTERNALS_H'
+*** Rinternals.h   2020-03-19 17:59:06.360000000 +0000
+--- Rinternals.h   2020-03-19 17:13:53.464000000 +0000
+***************
+*** 1210,1215 ****
+--- 1210,1216 ----
+  #define list3                 Rf_list3
+  #define list4                 Rf_list4
+  #define list5                 Rf_list5
++ #define list6                 Rf_list6
+  #define listAppend            Rf_listAppend
+  #define match                 Rf_match
+  #define matchE                        Rf_matchE
+***************
+*** 1374,1377 ****
+--- 1375,1380 ----
+  }
+  #endif
+
++ #define Rf_list6(x0, x1, x2, x3, x4, x5) ({ PROTECT(x0); x0 = Rf_cons(x0, Rf_list5(x1, x2, x3, x4, x5)); UNPROTECT(1); x0; })
++
+  #endif /* R_INTERNALS_H_ */
+
+_PATCH_R_INTERNALS_H


### PR DESCRIPTION
This compilation error has been blocking one of the CI jobs recently. The only solution I can think of is creating a bash script that conditionally patches the Rinternals.h, which is wonderfully insane, but lo and behold it worked!

(note: this is only OK because only some R package travis uses has dependency on Rcpp 1.0.4. Sparklyr currently does not depend on Rcpp 1.0.4 in any way)

Signed-off-by: Yitao Li <yitao@rstudio.com>