### PR TITLE
Allow sdf_query_plan to also get analyzed plan

### DIFF
--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -158,11 +158,13 @@ check_tidy <- function(o, exp.row = NULL, exp.col = NULL, exp.names = NULL) {
   }
 }
 
-sdf_query_plan <- function(x) {
+sdf_query_plan <- function(x, plan_type=c("optimizedPlan", "analyzed")) {
+  plan_type <- match.arg(plan_type)
+
   x %>%
     spark_dataframe() %>%
     invoke("queryExecution") %>%
-    invoke("optimizedPlan") %>%
+    invoke(plan_type) %>%
     invoke("toString") %>%
     strsplit("\n") %>%
     unlist()
@@ -379,13 +381,17 @@ skip_on_spark_master <- function() {
   if (is_on_master) skip("Test skipped on spark master")
 }
 
+is_testing_databricks_connect <- function() {
+  Sys.getenv("TEST_DATABRICKS_CONNECT") == "true"
+}
+
 skip_unless_databricks_connect <- function() {
-  if (Sys.getenv("TEST_DATABRICKS_CONNECT") != "true")
+  if (!is_testing_databricks_connect())
     skip("Test only runs on Databricks Connect")
 }
 
 skip_databricks_connect <- function() {
-  if (Sys.getenv("TEST_DATABRICKS_CONNECT") == "true")
+  if (is_testing_databricks_connect())
     skip("Test is skipped on Databricks Connect")
 }
 

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -122,7 +122,7 @@ test_that("'sample_n' and 'sample_frac' work in nontrivial queries (#1299)", {
 })
 
 test_that("'sdf_broadcast' forces broadcast hash join", {
-  if (sc$method == "databricks-connect") {
+  if (is_testing_databricks_connect()) {
     # DB Connect's optimized plans don't display much useful information when calling toString,
     # so we use the analyzed plan instead
     plan_type <- "analyzed"

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -122,13 +122,20 @@ test_that("'sample_n' and 'sample_frac' work in nontrivial queries (#1299)", {
 })
 
 test_that("'sdf_broadcast' forces broadcast hash join", {
-  skip_databricks_connect()
+  if (sc$method == "databricks-connect") {
+    # DB Connect's optimized plans don't display much useful information when calling toString,
+    # so we use the analyzed plan instead
+    plan_type <- "analyzed"
+  } else {
+    plan_type <- "optimizedPlan"
+  }
+
   query_plan <- df1_tbl %>%
     sdf_broadcast() %>%
     left_join(df2_tbl, by = "b") %>%
     spark_dataframe() %>%
     invoke("queryExecution") %>%
-    invoke("optimizedPlan") %>%
+    invoke(plan_type) %>%
     invoke("toString")
   expect_match(query_plan, "B|broadcast")
 })


### PR DESCRIPTION
Allow sdf_query_plan to also get analyzed plan, which is more useful for DB Connect. The PR adds an optional argument to `sdf_query_plan`, to get either the optimized or analyzed plan. When called with DB Connect, the optimized plan is just a LogicalRemoteExec "black box", and doesn't display much useful query information. Instead, the analyzed plan can be used to examine the query. 

For backwards compatibility, the `plan_type` argument of `sdf_query_plan` defaults to `optimizedPlan`, so that existing usage will have the same behavior.

This also fixes and enables two tests for DB Connect that check query plans. 