### PR TITLE
Enable some broom tests and other tests that pass on DB Connect

### DIFF
--- a/tests/testthat/test-broom-aft_survival_regression.R
+++ b/tests/testthat/test-broom-aft_survival_regression.R
@@ -1,6 +1,5 @@
 context("broom-aft_survival_regression")
 
-skip_databricks_connect()
 test_that("aft_survival_regression.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-als.R
+++ b/tests/testthat/test-broom-als.R
@@ -1,6 +1,5 @@
 context("broom-als")
 
-skip_databricks_connect()
 test_that("als.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-decision_tree.R
+++ b/tests/testthat/test-broom-decision_tree.R
@@ -1,6 +1,5 @@
 context("broom-decision_tree")
 
-skip_databricks_connect()
 test_that("decision_tree.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-gaussian_mixture.R
+++ b/tests/testthat/test-broom-gaussian_mixture.R
@@ -1,6 +1,5 @@
 context("broom-gaussian_mixture")
 
-skip_databricks_connect()
 test_that("gaussian_mixture.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-gaussian_mixture.R
+++ b/tests/testthat/test-broom-gaussian_mixture.R
@@ -1,5 +1,6 @@
 context("broom-gaussian_mixture")
 
+skip_databricks_connect()
 test_that("gaussian_mixture.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-gradient_boosted_trees.R
+++ b/tests/testthat/test-broom-gradient_boosted_trees.R
@@ -1,6 +1,5 @@
 context("broom-gradient_boosted_trees")
 
-skip_databricks_connect()
 test_that("gradient_boosted_trees.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-isotonic_regression.R
+++ b/tests/testthat/test-broom-isotonic_regression.R
@@ -1,6 +1,5 @@
 context("broom-isotonic_regression")
 
-skip_databricks_connect()
 test_that("isotonic_regression.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-lda.R
+++ b/tests/testthat/test-broom-lda.R
@@ -1,6 +1,5 @@
 context("broom-lda")
 
-skip_databricks_connect()
 test_that("lda.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-linear_svc.R
+++ b/tests/testthat/test-broom-linear_svc.R
@@ -1,6 +1,5 @@
 context("broom-linear_svc")
 
-skip_databricks_connect()
 test_that("linear_svc.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-logistic_regression.R
+++ b/tests/testthat/test-broom-logistic_regression.R
@@ -1,6 +1,5 @@
 context("broom-logistic_regression")
 
-skip_databricks_connect()
 test_that("logistic_regression.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-naive_bayes.R
+++ b/tests/testthat/test-broom-naive_bayes.R
@@ -1,6 +1,5 @@
 context("broom-naive_bayes")
 
-skip_databricks_connect()
 library(dplyr)
 
 test_that("naive_bayes.tidy() works", {

--- a/tests/testthat/test-broom-pca.R
+++ b/tests/testthat/test-broom-pca.R
@@ -1,6 +1,5 @@
 context("broom-pca")
 
-skip_databricks_connect()
 test_that("pca.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom-random_forest.R
+++ b/tests/testthat/test-broom-random_forest.R
@@ -1,6 +1,5 @@
 context("broom-random_forest")
 
-skip_databricks_connect()
 test_that("random_forest.tidy() works", {
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0")

--- a/tests/testthat/test-broom.R
+++ b/tests/testthat/test-broom.R
@@ -1,6 +1,5 @@
 context("broom")
 
-skip_databricks_connect()
 test_that("tidy.{glm type models} works", {
   sc <- testthat_spark_connection()
   test_requires("broom")

--- a/tests/testthat/test-column-extraction.R
+++ b/tests/testthat/test-column-extraction.R
@@ -1,6 +1,5 @@
 context("column separation")
 
-skip_databricks_connect()
 test_requires("dplyr")
 test_requires("janeaustenr")
 

--- a/tests/testthat/test-feature-one-hot-encoder-estimator.R
+++ b/tests/testthat/test-feature-one-hot-encoder-estimator.R
@@ -1,6 +1,5 @@
 context("ml feature one hot encoder estimator")
 
-skip_databricks_connect()
 test_that("ft_one_hot_encoder_estimator() default params", {
   test_requires_version(min_version="2.3.0", max_version="3.0.0")
   sc <- testthat_spark_connection()


### PR DESCRIPTION
Even though we don't fully support broom + DB Connect, enabling the tests that already pass will prevent regressions. Also enable some non-broom tests. 