### PR TITLE
comment out CI builds that are migrated to github action workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,51 +12,51 @@ r_github_packages:
 
 matrix:
   include:
-    - name: "Spark 1.6.3 (R 3.2, openjdk7)"
-      r: 3.2
-      env:
-        - SPARK_VERSION="1.6.3"
-        - JAVA_VERSION=openjdk7
-    - name: "Spark 2.2.1 (R oldrel, oraclejdk8)"
-      r: oldrel
-      warnings_are_errors: true
-      env:
-        - SPARK_VERSION="2.2.1"
-        - JAVA_VERSION=oraclejdk8
-    - name: "Spark 2.3.2 (R release, oraclejdk8)"
-      r: release
-      warnings_are_errors: true
-      env:
-        - SPARK_VERSION="2.3.2"
-        - JAVA_VERSION=oraclejdk8
-    - name: "Spark 2.4.4 (R release, oraclejdk8)"
-      r: release
-      r_packages:
-        - glmnet
-      warnings_are_errors: true
-      env:
-        - SPARK_VERSION="2.4.4"
-        - JAVA_VERSION=oraclejdk8
-        - CODE_COVERAGE="true"
-    - name: "Spark master (R release, oraclejdk8)"
-      r: release
-      warnings_are_errors: true
-      env:
-        - SPARK_VERSION="master"
-        - JAVA_VERSION=oraclejdk8
-    - name: "Spark master (R release, openjdk11)"
-      r: release
-      warnings_are_errors: true
-      env:
-        - SPARK_VERSION="master"
-        - JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
-    - name: "Livy 0.5.0 (R release, oraclejdk8, Spark 2.3.0)"
-      r: release
-      warnings_are_errors: true
-      env:
-        - LIVY_VERSION="0.5.0"
-        - SPARK_VERSION="2.3.0"
-        - JAVA_VERSION=oraclejdk8
+    # - name: "Spark 1.6.3 (R 3.2, openjdk7)"
+    #   r: 3.2
+    #   env:
+    #     - SPARK_VERSION="1.6.3"
+    #     - JAVA_VERSION=openjdk7
+    # - name: "Spark 2.2.1 (R oldrel, oraclejdk8)"
+    #   r: oldrel
+    #   warnings_are_errors: true
+    #   env:
+    #     - SPARK_VERSION="2.2.1"
+    #     - JAVA_VERSION=oraclejdk8
+    # - name: "Spark 2.3.2 (R release, oraclejdk8)"
+    #   r: release
+    #   warnings_are_errors: true
+    #   env:
+    #     - SPARK_VERSION="2.3.2"
+    #     - JAVA_VERSION=oraclejdk8
+    # - name: "Spark 2.4.4 (R release, oraclejdk8)"
+    #   r: release
+    #   r_packages:
+    #     - glmnet
+    #   warnings_are_errors: true
+    #   env:
+    #     - SPARK_VERSION="2.4.4"
+    #     - JAVA_VERSION=oraclejdk8
+    #     - CODE_COVERAGE="true"
+    # - name: "Spark master (R release, oraclejdk8)"
+    #   r: release
+    #   warnings_are_errors: true
+    #   env:
+    #     - SPARK_VERSION="master"
+    #     - JAVA_VERSION=oraclejdk8
+    # - name: "Spark master (R release, openjdk11)"
+    #   r: release
+    #   warnings_are_errors: true
+    #   env:
+    #     - SPARK_VERSION="master"
+    #     - JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
+    # - name: "Livy 0.5.0 (R release, oraclejdk8, Spark 2.3.0)"
+    #   r: release
+    #   warnings_are_errors: true
+    #   env:
+    #     - LIVY_VERSION="0.5.0"
+    #     - SPARK_VERSION="2.3.0"
+    #     - JAVA_VERSION=oraclejdk8
     - name: "Arrow 0.11.0 (ref = 'dc5df8f')"
       r: release
       warnings_are_errors: true
@@ -84,54 +84,54 @@ matrix:
         - ARROW_BRANCH="apache-arrow-0.13.0"
         - ARROW_SOURCE="install"
         - JAVA_VERSION=oraclejdk8
-    - name: "Arrow Devel (ref = '')"
-      r: release
-      dist: xenial
-      sudo: true
-      warnings_are_errors: true
-      env:
-        - ARROW_ENABLED="true"
-        - ARROW_VERSION="devel"
-        - ARROW_SOURCE="build"
-        - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre"
-        - LD_LIBRARY_PATH="/usr/local/lib"
-      addons:
-        apt:
-          packages:
-            - openjdk-8-jre
-    - name: "Deps Devel (tidyverse, r-lib, forge)"
-      warnings_are_errors: true
-      env: R_DEVEL_PACKAGES="true"
-      r_github_packages:
-        - tidyverse/dplyr
-        - tidyverse/dbplyr
-        - tidyverse/tibble
-        - r-lib/rlang
-        - rstudio/forge
-        - r-lib/ellipsis
-        - r-dbi/DBI
-  allow_failures:
-    - env: R_DEVEL_PACKAGES="true"
-    - r: release
-      dist: xenial
-      sudo: true
-      warnings_are_errors: true
-      env:
-        - ARROW_ENABLED="true"
-        - ARROW_VERSION="devel"
-        - ARROW_SOURCE="build"
-        - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre"
-        - LD_LIBRARY_PATH="/usr/local/lib"
-      addons:
-        apt:
-          packages:
-            - openjdk-8-jre
-    - r: release
-      warnings_are_errors: true
-      env:
-        - LIVY_VERSION="0.5.0"
-        - SPARK_VERSION="2.3.0"
-        - JAVA_VERSION=oraclejdk8
+    # - name: "Arrow Devel (ref = '')"
+    #   r: release
+    #   dist: xenial
+    #   sudo: true
+    #   warnings_are_errors: true
+    #   env:
+    #     - ARROW_ENABLED="true"
+    #     - ARROW_VERSION="devel"
+    #     - ARROW_SOURCE="build"
+    #     - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre"
+    #     - LD_LIBRARY_PATH="/usr/local/lib"
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - openjdk-8-jre
+    # - name: "Deps Devel (tidyverse, r-lib, forge)"
+    #   warnings_are_errors: true
+    #   env: R_DEVEL_PACKAGES="true"
+    #   r_github_packages:
+    #     - tidyverse/dplyr
+    #     - tidyverse/dbplyr
+    #     - tidyverse/tibble
+    #     - r-lib/rlang
+    #     - rstudio/forge
+    #     - r-lib/ellipsis
+    #     - r-dbi/DBI
+  # allow_failures:
+  #   - env: R_DEVEL_PACKAGES="true"
+  #   - r: release
+  #     dist: xenial
+  #     sudo: true
+  #     warnings_are_errors: true
+  #     env:
+  #       - ARROW_ENABLED="true"
+  #       - ARROW_VERSION="devel"
+  #       - ARROW_SOURCE="build"
+  #       - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre"
+  #       - LD_LIBRARY_PATH="/usr/local/lib"
+  #     addons:
+  #       apt:
+  #         packages:
+  #           - openjdk-8-jre
+  #   - r: release
+  #     warnings_are_errors: true
+  #     env:
+  #       - LIVY_VERSION="0.5.0"
+  #       - SPARK_VERSION="2.3.0"
+  #       - JAVA_VERSION=oraclejdk8
 
 before_install:
   - sudo mount -t tmpfs tmpfs /tmp

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -17,6 +17,7 @@ PerformanceReporter <- R6::R6Class("PerformanceReporter",
                                      n_skip = 0,
                                      n_warn = 0,
                                      n_fail = 0,
+                                     failures = c(),
 
                                      start_context = function(context) {
                                        private$print_last_test()
@@ -35,6 +36,7 @@ PerformanceReporter <- R6::R6Class("PerformanceReporter",
 
                                        if (is_error) {
                                          self$n_fail <- self$n_fail + 1
+                                         self$failures <- c(self$failures, paste0(test, " (Context: ", context, ")"))
                                        } else if (inherits(result, "expectation_skip")) {
                                          self$n_skip <- self$n_skip + 1
                                        } else if (inherits(result, "expectation_warning")) {
@@ -108,6 +110,9 @@ PerformanceReporter <- R6::R6Class("PerformanceReporter",
                                        self$cat_line("Failed:   ", format(self$n_fail, width = 5))
                                        self$cat_line("Warnings: ", format(self$n_warn, width = 5))
                                        self$cat_line("Skipped:  ", format(self$n_skip, width = 5))
+                                       if (length(self$failures) > 0)
+                                         self$cat_line("Failures:  ",
+                                                       do.call(paste, as.list(c(self$failures, sep = "\n"))))
                                        cat("\n")
                                      }
                                    ),

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -248,7 +248,8 @@ testthat_livy_connection <- function() {
         sparklyr.verbose = TRUE,
         sparklyr.connect.timeout = 120,
         sparklyr.log.invoke = "cat",
-        spark.sql.warehouse.dir = get_spark_warehouse_dir()
+        spark.sql.warehouse.dir = get_spark_warehouse_dir(),
+        sparklyr.livy.branch = "test/livy"
       ),
       version = version,
       sources = TRUE

--- a/tests/testthat/test-serialization.R
+++ b/tests/testthat/test-serialization.R
@@ -162,9 +162,9 @@ test_that("collect() can retrieve all data types correctly", {
     "date",        epoch_sdate,      "Date", epoch_rdate,      "Date", epoch_rdate,
     "timestamp",         stime,   "POSIXct",       rtime,   "POSIXct",       atime,
     "date",              sdate,      "Date",       rdate,      "Date",       rdate,
-    "string",                1, "character",         "1", "character",         "1",
-    "varchar(10)",           1, "character",         "1", "character",         "1",
-    "char(10)",              1, "character",         "1", "character",         "1",
+    "string",              "1", "character",         "1", "character",         "1",
+    "varchar(10)",         "1", "character",         "1", "character",         "1",
+    "char(10)",            "1", "character",         "1", "character",         "1",
     "boolean",          "true",   "logical",      "TRUE",   "logical",      "TRUE",
   )
 


### PR DESCRIPTION
- Unfortunately there are 2 CI builds (Arrow 0.11.0 & Arrow 0.13.0) that cannot be migrated to the new github action workflow yet
- Both ran into weird compilation errors either with thrift dependency or with Rcpp if building them with existing build scripts in the ci/ directory at dependency installation stage and all the workarounds I could think of did not fix those errors
- Meanwhile Travis is just downloading already compiled artifacts from its internal cache and running everything without compiling any source code at all, which is fine... but that means it won't offer us any insight whether something could be done differently to fix the compilation errors with github action workflow.
 - Also now that the Livy test is re-enabled, there is apparently some test failure that needs to be addressed there (this should be simple, but will be in another PR)

So, leaving those 2 in .travis.yml for now

Signed-off-by: Yitao Li <yitao@rstudio.com>