### PR TITLE
use jars from a test branch for testthat livy connections

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -17,6 +17,7 @@ PerformanceReporter <- R6::R6Class("PerformanceReporter",
                                      n_skip = 0,
                                      n_warn = 0,
                                      n_fail = 0,
+                                     failures = c(),
 
                                      start_context = function(context) {
                                        private$print_last_test()
@@ -35,6 +36,7 @@ PerformanceReporter <- R6::R6Class("PerformanceReporter",
 
                                        if (is_error) {
                                          self$n_fail <- self$n_fail + 1
+                                         self$failures <- c(self$failures, paste0(test, " (Context: ", context, ")"))
                                        } else if (inherits(result, "expectation_skip")) {
                                          self$n_skip <- self$n_skip + 1
                                        } else if (inherits(result, "expectation_warning")) {
@@ -108,6 +110,9 @@ PerformanceReporter <- R6::R6Class("PerformanceReporter",
                                        self$cat_line("Failed:   ", format(self$n_fail, width = 5))
                                        self$cat_line("Warnings: ", format(self$n_warn, width = 5))
                                        self$cat_line("Skipped:  ", format(self$n_skip, width = 5))
+                                       if (length(self$failures) > 0)
+                                         self$cat_line("Failures:  ",
+                                                       do.call(paste, as.list(c(self$failures, sep = "\n"))))
                                        cat("\n")
                                      }
                                    ),

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -248,7 +248,8 @@ testthat_livy_connection <- function() {
         sparklyr.verbose = TRUE,
         sparklyr.connect.timeout = 120,
         sparklyr.log.invoke = "cat",
-        spark.sql.warehouse.dir = get_spark_warehouse_dir()
+        spark.sql.warehouse.dir = get_spark_warehouse_dir(),
+        sparklyr.livy.branch = "test/livy"
       ),
       version = version,
       sources = TRUE

--- a/tests/testthat/test-serialization.R
+++ b/tests/testthat/test-serialization.R
@@ -162,9 +162,9 @@ test_that("collect() can retrieve all data types correctly", {
     "date",        epoch_sdate,      "Date", epoch_rdate,      "Date", epoch_rdate,
     "timestamp",         stime,   "POSIXct",       rtime,   "POSIXct",       atime,
     "date",              sdate,      "Date",       rdate,      "Date",       rdate,
-    "string",                1, "character",         "1", "character",         "1",
-    "varchar(10)",           1, "character",         "1", "character",         "1",
-    "char(10)",              1, "character",         "1", "character",         "1",
+    "string",              "1", "character",         "1", "character",         "1",
+    "varchar(10)",         "1", "character",         "1", "character",         "1",
+    "char(10)",            "1", "character",         "1", "character",         "1",
     "boolean",          "true",   "logical",      "TRUE",   "logical",      "TRUE",
   )
 


### PR DESCRIPTION
This is needed to make Livy tests pass after recent changes in https://github.com/sparklyr/sparklyr/pull/2348

Signed-off-by: Yitao Li <yitao@rstudio.com>