### PR TITLE
fix serialization test failure

### DIFF
--- a/tests/testthat/test-serialization.R
+++ b/tests/testthat/test-serialization.R
@@ -162,9 +162,9 @@ test_that("collect() can retrieve all data types correctly", {
     "date",        epoch_sdate,      "Date", epoch_rdate,      "Date", epoch_rdate,
     "timestamp",         stime,   "POSIXct",       rtime,   "POSIXct",       atime,
     "date",              sdate,      "Date",       rdate,      "Date",       rdate,
-    "string",                1, "character",         "1", "character",         "1",
-    "varchar(10)",           1, "character",         "1", "character",         "1",
-    "char(10)",              1, "character",         "1", "character",         "1",
+    "string",              "1", "character",         "1", "character",         "1",
+    "varchar(10)",         "1", "character",         "1", "character",         "1",
+    "char(10)",            "1", "character",         "1", "character",         "1",
     "boolean",          "true",   "logical",      "TRUE",   "logical",      "TRUE",
   )
 


### PR DESCRIPTION
For some unknown reason, this test started failing recently with a type mismatch error:

 error: No common type for `svalue` <character> and `svalue` <double> and is failing on both Travis and Github CI machines.

I have no idea why it only started failing recently. But the best guess off the top of my head is this change should fix it.

Signed-off-by: yl790 <yitao@rstudio.com>