### PR TITLE
ensure test performance reporter does not cause test failure

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -47,19 +47,21 @@ PerformanceReporter <- R6::R6Class("PerformanceReporter",
                                        }
 
                                        if (print_message) {
-                                        cat(
-                                          paste0(test, ": ", private$expectation_type(result), ": ", result$message),
-                                          "\n"
-                                        )
-                                         if (is_error) {
-                                           cat(
-                                             paste(
-                                               "  callstack:\n    ",
-                                               paste0(utils::limitedLabels(result$call), collapse = "\n    "),
-                                               "\n"
-                                             )
-                                           )
-                                         }
+                                        try({
+                                          cat(
+                                            paste0(test, ": ", private$expectation_type(result), ": ", result$message),
+                                            "\n"
+                                          )
+                                          if (is_error) {
+                                            cat(
+                                              paste(
+                                                "  callstack:\n    ",
+                                                paste0(utils::limitedLabels(result$call), collapse = "\n    "),
+                                                "\n"
+                                              )
+                                            )
+                                          }
+                                        })
                                        }
 
                                        if (identical(self$last_test, test)) {
@@ -118,12 +120,13 @@ PerformanceReporter <- R6::R6Class("PerformanceReporter",
                                    ),
                                    private = list(
                                      print_last_test = function() {
-                                       if (!is.na(self$last_test) &&
-                                           length(self$last_test) > 0 &&
-                                           length(self$last_test_time) > 0) {
-                                         cat(paste0(self$last_test, ": ", self$last_test_time, "\n"))
-                                       }
-
+                                       try({
+                                         if (!is.na(self$last_test) &&
+                                             length(self$last_test) > 0 &&
+                                             length(self$last_test_time) > 0) {
+                                           cat(paste0(self$last_test, ": ", self$last_test_time, "\n"))
+                                         }
+                                       })
                                        self$last_test <- NA_character_
                                      },
                                      expectation_type = function(exp) {


### PR DESCRIPTION
Sparklyr recently had a mini-crisis in test repeatability. A small number of test cases running in both GitHub action workflow and Travis that were previously passing started failing with empty call stack when running with R 3.2.

I think the patch version of R 3.2 must have changed in both CI envs (because nothing else changed that could affect those test cases...), and the new R 3.2.x runtime doesn't like this line `if (!is.na(self$last_test) && length(self$last_test) > 0 && length(self$last_test_time) >  ...)` for some reason and fails with 'missing value where TRUE/FALSE needed' -- So wrapping it in a try block to prevent that check from failing entire test cases.

Signed-off-by: yl790 <yitao@rstudio.com>