### PR TITLE
Update feature branch for livy connection

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -572,7 +572,7 @@ livy_connection_jars <- function(config, version) {
 
     target_jar <- dir(system.file("java", package = "sparklyr"), pattern = paste0("sparklyr-", target_version))
 
-    livy_branch <- spark_config_value(config, "sparklyr.livy.branch", "feature/sparklyr-1.1.0")
+    livy_branch <- spark_config_value(config, "sparklyr.livy.branch", "feature/sparklyr-1.2.0")
 
     livy_jars <- list(paste0(
       "https://github.com/sparklyr/sparklyr/blob/",

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -248,8 +248,7 @@ testthat_livy_connection <- function() {
         sparklyr.verbose = TRUE,
         sparklyr.connect.timeout = 120,
         sparklyr.log.invoke = "cat",
-        spark.sql.warehouse.dir = get_spark_warehouse_dir(),
-        sparklyr.livy.branch = "test/livy"
+        spark.sql.warehouse.dir = get_spark_warehouse_dir()
       ),
       version = version,
       sources = TRUE


### PR DESCRIPTION
This change is needed to prepare for Sparklyr 1.2.0 release

 - updated feature branch used by livy connection
 - and also using the same branch for testthat livy connection instead of a separate test branch

Signed-off-by: yl790 <yitao@rstudio.com>