### PR TITLE
Fix summary() in ml_linear_regression when intercept = FALSE

### DIFF
--- a/R/ml_model_linear_regression.R
+++ b/R/ml_model_linear_regression.R
@@ -12,10 +12,13 @@ new_ml_model_linear_regression <- function(pipeline_model, formula, dataset, lab
   coefficients <- model$coefficients
   names(coefficients) <- m$feature_names
 
-  m$coefficients <- if (ml_param(model, "fit_intercept"))
+  m$coefficients <- if (ml_param(model, "fit_intercept")){
     rlang::set_names(
       c(invoke(jobj, "intercept"), model$coefficients),
       c("(Intercept)", m$feature_names))
+  } else {
+    coefficients
+  }
 
   m$summary <- model$summary
 


### PR DESCRIPTION
This PR is related to #2230

Here is an example that you can run 
```
library(dplyr)
library(sparklyr)

sc <- spark_connect(master = "local")

# copy mtcars into spark
mtcars_tbl <- copy_to(sc, 
                      df = mtcars, 
                      overwrite = TRUE)

  # fit LM with intercept 
  fit_with_intercept <- mtcars_tbl %>%
  ml_linear_regression(mpg ~ wt + cyl, 
                       fit_intercept = TRUE) # param set to TRUE (default)

# fit LM without intercept 
fit_without_intercept <- mtcars_tbl %>%
  ml_linear_regression(mpg ~ wt + cyl,
                       fit_intercept = FALSE) # param set to FALSE 
```

with intercept
```
fit_with_intercept %>% summary()
```
```
Deviance Residuals:
    Min      1Q  Median      3Q     Max 
-4.2893 -1.5512 -0.4684  1.5743  6.1004 

Coefficients:
(Intercept)          wt         cyl 
  39.686261   -3.190972   -1.507795 

R-Squared: 0.8302
Root Mean Squared Error: 2.444
```


without intercept
```
fit_without_intercept %>% summary()
```
```
Deviance Residuals:
    Min      1Q  Median      3Q     Max 
-13.466  -6.181   1.476  10.597  22.996 

Coefficients:
      wt      cyl 
1.173788 2.187405 

R-Squared: 0.735
Root Mean Squared Error: 10.78
``` 

