### PR TITLE
Avoid tar-ing all packages in spark-apply-bundle test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Cache Arrow build artifacts if necessary
         id: cache-arrow-build-artifacts
         if: runner.os != 'Windows' && env.ARROW_SOURCE == 'build' && env.ARROW_VERSION != 'devel'
-        uses: actions/cache@v1
+        uses: actions/cache@master
         with:
           path:
             /tmp/apache-arrow-${{ env.ARROW_VERSION }}-build
@@ -137,7 +137,7 @@ jobs:
         shell: bash
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v1
+        uses: actions/cache@master
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.r }}-${{ env.ARROW_ENABLED }}-${{ hashFiles('DESCRIPTION') }}

--- a/tests/testthat/test-spark-apply-bundle.R
+++ b/tests/testthat/test-spark-apply-bundle.R
@@ -3,7 +3,7 @@ context("spark apply bundle")
 sc <- testthat_spark_connection()
 
 test_that("'spark_apply_bundle' can `worker_spark_apply_unbundle`", {
-  bundlePath <- spark_apply_bundle()
+  bundlePath <- spark_apply_bundle(packages = c("ggplot2", "purrr"))
   unbundlePath <- worker_spark_apply_unbundle(bundlePath, tempdir(), "package")
 
   unlink(bundlePath, recursive = TRUE)


### PR DESCRIPTION
because it's time consuming and also fills up all available disk space, potentially causing other problems on the CI host