### PR TITLE
revise install_r_dependencies.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Cache Arrow build artifacts if necessary
         id: cache-arrow-build-artifacts
         if: runner.os != 'Windows' && env.ARROW_SOURCE == 'build' && env.ARROW_VERSION != 'devel'
-        uses: actions/cache@v1
+        uses: actions/cache@master
         with:
           path:
             /tmp/apache-arrow-${{ env.ARROW_VERSION }}-build
@@ -137,7 +137,7 @@ jobs:
         shell: bash
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v1
+        uses: actions/cache@master
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.r }}-${{ env.ARROW_ENABLED }}-${{ hashFiles('DESCRIPTION') }}

--- a/ci/install_r_dependencies.sh
+++ b/ci/install_r_dependencies.sh
@@ -4,10 +4,7 @@ export MAKEFLAGS="-j$(($(nproc) + 1))"
 
 R_REMOTES_NO_ERRORS_FROM_WARNINGS=true Rscript <(
 cat << _RSCRIPT_EOF_
-  install.packages("remotes")
-  library(remotes)
-  for (x in c("r-lib/httr", "omegahat/RCurl"))
-    try(remotes::install_github(x))
-  remotes::install_deps(dependencies = c("Imports", "Suggests"))
+  install.packages("devtools")
+  devtools::install_deps()
 _RSCRIPT_EOF_
 )


### PR DESCRIPTION
remotes::install_deps was installing way too many packages for some reason... we most likely only need packages from devtools::install_deps, a list way shorter than what remotes::install_deps came up with