### PR TITLE
re-build html references

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Cache Arrow build artifacts if necessary
         id: cache-arrow-build-artifacts
         if: runner.os != 'Windows' && env.ARROW_SOURCE == 'build' && env.ARROW_VERSION != 'devel'
-        uses: actions/cache@v1
+        uses: actions/cache@master
         with:
           path:
             /tmp/apache-arrow-${{ env.ARROW_VERSION }}-build
@@ -137,7 +137,7 @@ jobs:
         shell: bash
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v1
+        uses: actions/cache@master
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.r }}-${{ env.ARROW_ENABLED }}-${{ hashFiles('DESCRIPTION') }}

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -247,6 +247,7 @@ reference:
     - spark_apply
     - spark_apply_bundle
     - spark_apply_log
+    - registerDoSpark
   - title: Livy
     contents:
     - livy_available_versions

--- a/docs/reference/registerDoSpark.html
+++ b/docs/reference/registerDoSpark.html
@@ -1,0 +1,59 @@
+---
+title: "Register a Prallel Backend"
+aliases:
+  - reference/sparklyr/latest/registerDoSpark.html
+---
+
+    <div>
+
+    <div>
+    <ul data-gumshoe>
+    <li><a href="#arguments">Arguments</a></li>
+    <li><a href="#value">Value</a></li>
+    <li><a href="#examples">Examples</a></li>
+    </ul>
+    </div>
+
+    <div>
+
+    <p>Registers a parallel backend using the <code>foreach</code> package.</p>
+
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class='fu'>registerDoSpark</span>(<span class='no'>spark_conn</span>, <span class='no'>...</span>)</code></pre></div>
+
+    <h2 id="arguments">Arguments</h2>
+    <table class="ref-arguments">
+
+    <colgroup>
+      <col class="name" />
+      <col class="desc" />
+    </colgroup>
+
+    <tr>
+      <td>spark_conn</td>
+      <td><p>spark connection to use</p></td>
+    </tr>
+    <tr>
+      <td>...</td>
+      <td><p>additional options for sparklyr parallel backend
+(currently only the only valid option is nocompile = T, F)</p></td>
+    </tr>
+    </table>
+
+    <h2 id="value">Value</h2>
+
+    <p>None</p>
+
+    <h2 id="examples">Examples</h2>
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
+
+<span class='no'>sc</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='spark-connections.html'>spark_connect</a></span>(<span class='kw'>master</span> <span class='kw'>=</span> <span class='st'>"local"</span>)
+<span class='fu'>registerDoSpark</span>(<span class='no'>sc</span>, <span class='kw'>nocompile</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>)
+}</div></code></pre></div>
+
+    </div>
+
+    </div>
+
+
+
+

--- a/docs/reference/sdf_drop_duplicates.html
+++ b/docs/reference/sdf_drop_duplicates.html
@@ -1,0 +1,47 @@
+---
+title: "Remove duplicates from a Spark DataFrame"
+aliases:
+  - reference/sparklyr/latest/sdf_drop_duplicates.html
+---
+
+    <div>
+
+    <div>
+    <ul data-gumshoe>
+    <li><a href="#arguments">Arguments</a></li>
+    </ul>
+    </div>
+
+    <div>
+
+    <p>Remove duplicates from a Spark DataFrame</p>
+
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class='fu'>sdf_drop_duplicates</span>(<span class='no'>x</span>, <span class='kw'>cols</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</code></pre></div>
+
+    <h2 id="arguments">Arguments</h2>
+    <table class="ref-arguments">
+
+    <colgroup>
+      <col class="name" />
+      <col class="desc" />
+    </colgroup>
+
+    <tr>
+      <td>x</td>
+      <td><p>An object coercible to a Spark DataFrame</p></td>
+    </tr>
+    <tr>
+      <td>cols</td>
+      <td><p>Subset of Columns to consider, given as a character vector</p></td>
+    </tr>
+    </table>
+
+
+
+    </div>
+
+    </div>
+
+
+
+

--- a/docs/reference/spark_config_packages.html
+++ b/docs/reference/spark_config_packages.html
@@ -1,0 +1,51 @@
+---
+title: "Creates Spark Configuration"
+aliases:
+  - reference/sparklyr/latest/spark_config_packages.html
+---
+
+    <div>
+
+    <div>
+    <ul data-gumshoe>
+    <li><a href="#arguments">Arguments</a></li>
+    </ul>
+    </div>
+
+    <div>
+
+    <p>Creates Spark Configuration</p>
+
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class='fu'>spark_config_packages</span>(<span class='no'>config</span>, <span class='no'>packages</span>, <span class='no'>version</span>)</code></pre></div>
+
+    <h2 id="arguments">Arguments</h2>
+    <table class="ref-arguments">
+
+    <colgroup>
+      <col class="name" />
+      <col class="desc" />
+    </colgroup>
+
+    <tr>
+      <td>config</td>
+      <td><p>The Spark configuration object.</p></td>
+    </tr>
+    <tr>
+      <td>packages</td>
+      <td><p>A list of named packages or versioned packagese to add.</p></td>
+    </tr>
+    <tr>
+      <td>version</td>
+      <td><p>The version of Spark being used.</p></td>
+    </tr>
+    </table>
+
+
+
+    </div>
+
+    </div>
+
+
+
+

--- a/docs/reference/stream_read_delta.html
+++ b/docs/reference/stream_read_delta.html
@@ -1,0 +1,100 @@
+---
+title: "Read Delta Stream"
+aliases:
+  - reference/sparklyr/latest/stream_read_delta.html
+---
+
+    <div>
+
+    <div>
+    <ul data-gumshoe>
+    <li><a href="#arguments">Arguments</a></li>
+    <li><a href="#details">Details</a></li>
+    <li><a href="#see-also">See also</a></li>
+    <li><a href="#examples">Examples</a></li>
+    </ul>
+    </div>
+
+    <div>
+
+    <p>Reads a Delta Lake table as a Spark dataframe stream.</p>
+
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class='fu'>stream_read_delta</span>(<span class='no'>sc</span>, <span class='no'>path</span>, <span class='kw'>name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>options</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(), <span class='no'>...</span>)</code></pre></div>
+
+    <h2 id="arguments">Arguments</h2>
+    <table class="ref-arguments">
+
+    <colgroup>
+      <col class="name" />
+      <col class="desc" />
+    </colgroup>
+
+    <tr>
+      <td>sc</td>
+      <td><p>A <code>spark_connection</code>.</p></td>
+    </tr>
+    <tr>
+      <td>path</td>
+      <td><p>The path to the file. Needs to be accessible from the cluster.
+Supports the <samp>"hdfs://"</samp>, <samp>"s3a://"</samp> and <samp>"file://"</samp> protocols.</p></td>
+    </tr>
+    <tr>
+      <td>name</td>
+      <td><p>The name to assign to the newly generated stream.</p></td>
+    </tr>
+    <tr>
+      <td>options</td>
+      <td><p>A list of strings with additional options.</p></td>
+    </tr>
+    <tr>
+      <td>...</td>
+      <td><p>Optional arguments; currently unused.</p></td>
+    </tr>
+    </table>
+
+    <h2 id="details">Details</h2>
+
+    <p>Please note that Delta Lake requires installing the appropriate
+package by setting the <code>packages</code> parameter to <code>"delta"</code> in <code><a href='spark-connections.html'>spark_connect()</a></code></p>
+    <h2 id="see-also">See also</h2>
+
+    <div class='dont-index'><p>Other Spark stream serialization: 
+<code><a href='stream_read_csv.html'>stream_read_csv</a>()</code>,
+<code><a href='stream_read_json.html'>stream_read_json</a>()</code>,
+<code><a href='stream_read_kafka.html'>stream_read_kafka</a>()</code>,
+<code><a href='stream_read_orc.html'>stream_read_orc</a>()</code>,
+<code><a href='stream_read_parquet.html'>stream_read_parquet</a>()</code>,
+<code><a href='stream_read_socket.html'>stream_read_socket</a>()</code>,
+<code><a href='stream_read_text.html'>stream_read_text</a>()</code>,
+<code><a href='stream_write_console.html'>stream_write_console</a>()</code>,
+<code><a href='stream_write_csv.html'>stream_write_csv</a>()</code>,
+<code><a href='stream_write_delta.html'>stream_write_delta</a>()</code>,
+<code><a href='stream_write_json.html'>stream_write_json</a>()</code>,
+<code><a href='stream_write_kafka.html'>stream_write_kafka</a>()</code>,
+<code><a href='stream_write_memory.html'>stream_write_memory</a>()</code>,
+<code><a href='stream_write_orc.html'>stream_write_orc</a>()</code>,
+<code><a href='stream_write_parquet.html'>stream_write_parquet</a>()</code>,
+<code><a href='stream_write_text.html'>stream_write_text</a>()</code></p></div>
+
+    <h2 id="examples">Examples</h2>
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
+
+<span class='fu'><a href='https://rdrr.io/r/base/library.html'>library</a></span>(<span class='no'>sparklyr</span>)
+<span class='no'>sc</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='spark-connections.html'>spark_connect</a></span>(<span class='kw'>master</span> <span class='kw'>=</span> <span class='st'>"local"</span>, <span class='kw'>version</span> <span class='kw'>=</span> <span class='st'>"2.4"</span>, <span class='kw'>packages</span> <span class='kw'>=</span> <span class='st'>"delta"</span>)
+
+<span class='fu'><a href='sdf_len.html'>sdf_len</a></span>(<span class='no'>sc</span>, <span class='fl'>5</span>) <span class='kw'>%&gt;%</span> <span class='fu'><a href='spark_write_delta.html'>spark_write_delta</a></span>(<span class='kw'>path</span> <span class='kw'>=</span> <span class='st'>"delta-test"</span>)
+
+<span class='no'>stream</span> <span class='kw'>&lt;-</span> <span class='fu'>stream_read_delta</span>(<span class='no'>sc</span>, <span class='st'>"delta-test"</span>) <span class='kw'>%&gt;%</span>
+  <span class='fu'><a href='stream_write_json.html'>stream_write_json</a></span>(<span class='st'>"json-out"</span>)
+
+<span class='fu'><a href='stream_stop.html'>stream_stop</a></span>(<span class='no'>stream</span>)
+
+}</div></code></pre></div>
+
+    </div>
+
+    </div>
+
+
+
+

--- a/docs/reference/stream_read_socket.html
+++ b/docs/reference/stream_read_socket.html
@@ -1,0 +1,95 @@
+---
+title: "Read Socket Stream"
+aliases:
+  - reference/sparklyr/latest/stream_read_socket.html
+---
+
+    <div>
+
+    <div>
+    <ul data-gumshoe>
+    <li><a href="#arguments">Arguments</a></li>
+    <li><a href="#see-also">See also</a></li>
+    <li><a href="#examples">Examples</a></li>
+    </ul>
+    </div>
+
+    <div>
+
+    <p>Reads a Socket stream as a Spark dataframe stream.</p>
+
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class='fu'>stream_read_socket</span>(<span class='no'>sc</span>, <span class='kw'>name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>columns</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>options</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(), <span class='no'>...</span>)</code></pre></div>
+
+    <h2 id="arguments">Arguments</h2>
+    <table class="ref-arguments">
+
+    <colgroup>
+      <col class="name" />
+      <col class="desc" />
+    </colgroup>
+
+    <tr>
+      <td>sc</td>
+      <td><p>A <code>spark_connection</code>.</p></td>
+    </tr>
+    <tr>
+      <td>name</td>
+      <td><p>The name to assign to the newly generated stream.</p></td>
+    </tr>
+    <tr>
+      <td>columns</td>
+      <td><p>A vector of column names or a named vector of column types.
+If specified, the elements can be <code>"binary"</code> for <code>BinaryType</code>,
+<code>"boolean"</code> for <code>BooleanType</code>, <code>"byte"</code> for <code>ByteType</code>,
+<code>"integer"</code> for <code>IntegerType</code>, <code>"integer64"</code> for <code>LongType</code>,
+<code>"double"</code> for <code>DoubleType</code>, <code>"character"</code> for <code>StringType</code>,
+<code>"timestamp"</code> for <code>TimestampType</code> and <code>"date"</code> for <code>DateType</code>.</p></td>
+    </tr>
+    <tr>
+      <td>options</td>
+      <td><p>A list of strings with additional options.</p></td>
+    </tr>
+    <tr>
+      <td>...</td>
+      <td><p>Optional arguments; currently unused.</p></td>
+    </tr>
+    </table>
+
+    <h2 id="see-also">See also</h2>
+
+    <div class='dont-index'><p>Other Spark stream serialization: 
+<code><a href='stream_read_csv.html'>stream_read_csv</a>()</code>,
+<code><a href='stream_read_delta.html'>stream_read_delta</a>()</code>,
+<code><a href='stream_read_json.html'>stream_read_json</a>()</code>,
+<code><a href='stream_read_kafka.html'>stream_read_kafka</a>()</code>,
+<code><a href='stream_read_orc.html'>stream_read_orc</a>()</code>,
+<code><a href='stream_read_parquet.html'>stream_read_parquet</a>()</code>,
+<code><a href='stream_read_text.html'>stream_read_text</a>()</code>,
+<code><a href='stream_write_console.html'>stream_write_console</a>()</code>,
+<code><a href='stream_write_csv.html'>stream_write_csv</a>()</code>,
+<code><a href='stream_write_delta.html'>stream_write_delta</a>()</code>,
+<code><a href='stream_write_json.html'>stream_write_json</a>()</code>,
+<code><a href='stream_write_kafka.html'>stream_write_kafka</a>()</code>,
+<code><a href='stream_write_memory.html'>stream_write_memory</a>()</code>,
+<code><a href='stream_write_orc.html'>stream_write_orc</a>()</code>,
+<code><a href='stream_write_parquet.html'>stream_write_parquet</a>()</code>,
+<code><a href='stream_write_text.html'>stream_write_text</a>()</code></p></div>
+
+    <h2 id="examples">Examples</h2>
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
+
+<span class='no'>sc</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='spark-connections.html'>spark_connect</a></span>(<span class='kw'>master</span> <span class='kw'>=</span> <span class='st'>"local"</span>)
+
+<span class='co'># Start socket server from terminal, example: nc -lk 9999</span>
+<span class='no'>stream</span> <span class='kw'>&lt;-</span> <span class='fu'>stream_read_socket</span>(<span class='no'>sc</span>, <span class='kw'>options</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(<span class='kw'>host</span> <span class='kw'>=</span> <span class='st'>"localhost"</span>, <span class='kw'>port</span> <span class='kw'>=</span> <span class='fl'>9999</span>))
+<span class='no'>stream</span>
+
+}</div></code></pre></div>
+
+    </div>
+
+    </div>
+
+
+
+

--- a/docs/reference/stream_write_delta.html
+++ b/docs/reference/stream_write_delta.html
@@ -1,0 +1,115 @@
+---
+title: "Write Delta Stream"
+aliases:
+  - reference/sparklyr/latest/stream_write_delta.html
+---
+
+    <div>
+
+    <div>
+    <ul data-gumshoe>
+    <li><a href="#arguments">Arguments</a></li>
+    <li><a href="#details">Details</a></li>
+    <li><a href="#see-also">See also</a></li>
+    <li><a href="#examples">Examples</a></li>
+    </ul>
+    </div>
+
+    <div>
+
+    <p>Writes a Spark dataframe stream into a Delta Lake table.</p>
+
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class='fu'>stream_write_delta</span>(
+  <span class='no'>x</span>,
+  <span class='no'>path</span>,
+  <span class='kw'>mode</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"append"</span>, <span class='st'>"complete"</span>, <span class='st'>"update"</span>),
+  <span class='kw'>checkpoint</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span>(<span class='st'>"checkpoints"</span>, <span class='fu'><a href='random_string.html'>random_string</a></span>(<span class='st'>""</span>)),
+  <span class='kw'>options</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(),
+  <span class='no'>...</span>
+)</code></pre></div>
+
+    <h2 id="arguments">Arguments</h2>
+    <table class="ref-arguments">
+
+    <colgroup>
+      <col class="name" />
+      <col class="desc" />
+    </colgroup>
+
+    <tr>
+      <td>x</td>
+      <td><p>A Spark DataFrame or dplyr operation</p></td>
+    </tr>
+    <tr>
+      <td>path</td>
+      <td><p>The path to the file. Needs to be accessible from the cluster.
+Supports the <samp>"hdfs://"</samp>, <samp>"s3a://"</samp> and <samp>"file://"</samp> protocols.</p></td>
+    </tr>
+    <tr>
+      <td>mode</td>
+      <td><p>Specifies how data is written to a streaming sink. Valid values are
+<code>"append"</code>, <code>"complete"</code> or <code>"update"</code>.</p></td>
+    </tr>
+    <tr>
+      <td>checkpoint</td>
+      <td><p>The location where the system will write all the checkpoint
+information to guarantee end-to-end fault-tolerance.</p></td>
+    </tr>
+    <tr>
+      <td>options</td>
+      <td><p>A list of strings with additional options.</p></td>
+    </tr>
+    <tr>
+      <td>...</td>
+      <td><p>Optional arguments; currently unused.</p></td>
+    </tr>
+    </table>
+
+    <h2 id="details">Details</h2>
+
+    <p>Please note that Delta Lake requires installing the appropriate
+package by setting the <code>packages</code> parameter to <code>"delta"</code> in <code><a href='spark-connections.html'>spark_connect()</a></code></p>
+    <h2 id="see-also">See also</h2>
+
+    <div class='dont-index'><p>Other Spark stream serialization: 
+<code><a href='stream_read_csv.html'>stream_read_csv</a>()</code>,
+<code><a href='stream_read_delta.html'>stream_read_delta</a>()</code>,
+<code><a href='stream_read_json.html'>stream_read_json</a>()</code>,
+<code><a href='stream_read_kafka.html'>stream_read_kafka</a>()</code>,
+<code><a href='stream_read_orc.html'>stream_read_orc</a>()</code>,
+<code><a href='stream_read_parquet.html'>stream_read_parquet</a>()</code>,
+<code><a href='stream_read_socket.html'>stream_read_socket</a>()</code>,
+<code><a href='stream_read_text.html'>stream_read_text</a>()</code>,
+<code><a href='stream_write_console.html'>stream_write_console</a>()</code>,
+<code><a href='stream_write_csv.html'>stream_write_csv</a>()</code>,
+<code><a href='stream_write_json.html'>stream_write_json</a>()</code>,
+<code><a href='stream_write_kafka.html'>stream_write_kafka</a>()</code>,
+<code><a href='stream_write_memory.html'>stream_write_memory</a>()</code>,
+<code><a href='stream_write_orc.html'>stream_write_orc</a>()</code>,
+<code><a href='stream_write_parquet.html'>stream_write_parquet</a>()</code>,
+<code><a href='stream_write_text.html'>stream_write_text</a>()</code></p></div>
+
+    <h2 id="examples">Examples</h2>
+    <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
+
+<span class='fu'><a href='https://rdrr.io/r/base/library.html'>library</a></span>(<span class='no'>sparklyr</span>)
+<span class='no'>sc</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='spark-connections.html'>spark_connect</a></span>(<span class='kw'>master</span> <span class='kw'>=</span> <span class='st'>"local"</span>, <span class='kw'>version</span> <span class='kw'>=</span> <span class='st'>"2.4"</span>, <span class='kw'>packages</span> <span class='kw'>=</span> <span class='st'>"delta"</span>)
+
+<span class='fu'><a href='https://rdrr.io/r/base/files2.html'>dir.create</a></span>(<span class='st'>"text-in"</span>)
+<span class='fu'><a href='https://rdrr.io/r/base/writeLines.html'>writeLines</a></span>(<span class='st'>"A text entry"</span>, <span class='st'>"text-in/text.txt"</span>)
+
+<span class='no'>text_path</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://rdrr.io/r/base/file.path.html'>file.path</a></span>(<span class='st'>"file://"</span>, <span class='fu'><a href='https://rdrr.io/r/base/getwd.html'>getwd</a></span>(), <span class='st'>"text-in"</span>)
+
+<span class='no'>stream</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='stream_read_text.html'>stream_read_text</a></span>(<span class='no'>sc</span>, <span class='no'>text_path</span>) <span class='kw'>%&gt;%</span> <span class='fu'>stream_write_delta</span>(<span class='kw'>path</span> <span class='kw'>=</span> <span class='st'>"delta-test"</span>)
+
+<span class='fu'><a href='stream_stop.html'>stream_stop</a></span>(<span class='no'>stream</span>)
+
+}</div></code></pre></div>
+
+    </div>
+
+    </div>
+
+
+
+


### PR DESCRIPTION
- most likely need to re-build HTML references for sparklyr 1.2.0 release
- need to add `registerDoSpark` to _pkgdown.yml