### PR TITLE
Fix warnings for deprecated function

### DIFF
--- a/R/ml_model_constructors.R
+++ b/R/ml_model_constructors.R
@@ -46,9 +46,8 @@ new_ml_model <- function(pipeline_model, formula, dataset, ..., class = characte
   predictor <- stages[[length(stages)]]
 
   # for pipeline, fix data prep transformation but use the un-fitted estimator predictor
-  pipeline <- stages %>%
-    head(-1) %>%
-    rlang::invoke(ml_pipeline, ., uid = ml_uid(pipeline_model)) %>%
+  pipeline <- stages %>% head(-1)
+  pipeline <- rlang::exec(ml_pipeline, !!!pipeline, uid = ml_uid(pipeline_model)) %>%
     ml_add_stage(predictor)
 
   # workaround for https://issues.apache.org/jira/browse/SPARK-19953

--- a/R/ml_stat.R
+++ b/R/ml_stat.R
@@ -66,8 +66,8 @@ ml_corr <- function(x, columns = NULL, method = c("pearson", "spearman")) {
     invoke("first") %>%
     sapply(invoke, "toArray") %>%
     matrix(nrow = num_features) %>%
-    dplyr::as_tibble() %>%
-    dplyr::rename(!!!rlang::set_names(paste0("V", seq_len(num_features)),
+    dplyr::as_tibble(.name_repair = "unique") %>%
+    dplyr::rename(!!!rlang::set_names(paste0("...", seq_len(num_features)),
                                       feature_names)
                   )
 }

--- a/R/mutation.R
+++ b/R/mutation.R
@@ -97,7 +97,7 @@ sdf_bind_rows <- function(..., id = NULL) {
       lapply(function(x) invoke(x, "dataType")) %>%
       lapply(function(x) invoke(x, "typeName")) %>%
       unlist()
-    dplyr::data_frame(name = col_names, type = col_types)
+    dplyr::tibble(name = col_names, type = col_types)
   })
 
   master_schema <- schemas %>%

--- a/R/tidiers_ml_isotonic_regression.R
+++ b/R/tidiers_ml_isotonic_regression.R
@@ -12,8 +12,8 @@ NULL
 tidy.ml_model_isotonic_regression <- function(x,
                                                   ...){
 
-  tibble::data_frame(boundaries = x$model$boundaries(),
-                     predictions = x$model$predictions())
+  dplyr::tibble(boundaries = x$model$boundaries(),
+                predictions = x$model$predictions())
 
 }
 

--- a/R/tidiers_ml_lda.R
+++ b/R/tidiers_ml_lda.R
@@ -15,10 +15,10 @@ tidy.ml_model_lda <- function(x,
 
   term <- ml_vocabulary(x)
   topics_matrix <- x$model$topics_matrix() %>%
-    dplyr::as_tibble()
+    dplyr::as_tibble(.name_repair = "unique")
 
   k <- x$model$param_map$k
-  names(topics_matrix) <- 0:(k - 1)
+  names(topics_matrix) <- as.character(0:(k - 1))
 
   dplyr::bind_cols(term = term, topics_matrix) %>%
     tidyr::gather(!!"topic", beta, -term, convert = TRUE) %>%

--- a/R/tidiers_ml_multilayer_perceptron.R
+++ b/R/tidiers_ml_multilayer_perceptron.R
@@ -67,5 +67,6 @@ glance.ml_model_multilayer_perceptron_classification <- function(x, ...) {
   c(input_units = input,
     hidden,
     output_units = output) %>%
-    dplyr::data_frame_()
+    as.list() %>%
+    dplyr::as_tibble()
 }

--- a/R/tidiers_pca.R
+++ b/R/tidiers_pca.R
@@ -38,12 +38,10 @@ glance.ml_model_pca <- function(x, ...) {
   names(explained_variance) <- purrr::map_chr(names(explained_variance),
                  function(e) paste0("explained_variance_", e))
 
-  k <- x$k
+  k <- c("k" = x$k)
 
   c(k, explained_variance) %>%
-    t() %>%
-    dplyr::as_tibble() %>%
-    dplyr::rename(k = !!"V1")
-
+    as.list() %>%
+    dplyr::as_tibble()
 }
 

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -335,9 +335,10 @@ test_param_setting <- function(sc, fn, test_args) {
 test_default_args <- function(sc, fn) {
   default_args <- rlang::fn_fmls(fn) %>%
     as.list() %>%
-    purrr::discard(~ is.symbol(.x) || is.language(.x)) %>%
-    rlang::modify(uid = NULL) %>%
-    purrr::compact()
+    purrr::discard(~ is.symbol(.x) || is.language(.x))
+
+  default_args$Uid <- NULL # rlang::modify is deprecated
+  default_args <- purrr::compact(default_args)
 
   params <- do.call(fn, list(x = sc)) %>%
     ml_params()

--- a/tests/testthat/test-column-extraction.R
+++ b/tests/testthat/test-column-extraction.R
@@ -85,7 +85,7 @@ test_that("we can separate struct columns (#690)", {
     to = as.Date("2017-01-01"),
     by = "1 day")
 
-  date_sdf <- copy_to(sc, tibble::data_frame(event_date = as.character(date_seq)),
+  date_sdf <- copy_to(sc, tibble(event_date = as.character(date_seq)),
                       overwrite = TRUE)
 
   sliding_window_sdf <- date_sdf %>%

--- a/tests/testthat/test-copy-to.R
+++ b/tests/testthat/test-copy-to.R
@@ -3,7 +3,7 @@ context("copy data")
 sc <- testthat_spark_connection()
 
 test_that("sdf_copy_to works for default serializer", {
-  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble()
+  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble(.name_repair = "unique")
   df_tbl <- sdf_copy_to(sc, df, overwrite = TRUE)
 
   expect_equal(
@@ -15,7 +15,7 @@ test_that("sdf_copy_to works for default serializer", {
 test_that("sdf_copy_to works for scala serializer", {
   skip_livy()
 
-  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble()
+  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble(.name_repair = "unique")
   df_tbl <- sdf_copy_to(sc, df, overwrite = TRUE, serializer = "csv_file_scala")
 
   expect_equal(
@@ -28,7 +28,7 @@ test_that("sdf_copy_to works for csv serializer", {
   skip_databricks_connect()
   skip_livy()
 
-  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble()
+  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble(.name_repair = "unique")
   df_tbl <- sdf_copy_to(sc, df, overwrite = TRUE, serializer = "csv_file")
 
   expect_equal(
@@ -48,7 +48,7 @@ test_that("spark_table_name() doesn't warn for multiline expression (#1386)", {
 })
 
 test_that("sdf_copy_to supports list of callbacks", {
-  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble()
+  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_tibble(.name_repair = "unique")
   df_tbl <- sdf_copy_to(sc, list(~df, ~df), overwrite = TRUE)
 
   expect_equal(

--- a/tests/testthat/test-dplyr-hive-operators.R
+++ b/tests/testthat/test-dplyr-hive-operators.R
@@ -5,9 +5,9 @@ sc <- testthat_spark_connection()
 test_that("regex relational operators work", {
   test_requires("dplyr")
 
-  hello <- data_frame(hello = c("hello my friend",
-                                "hello my dog",
-                                "hello my cat"))
+  hello <- tibble(hello = c("hello my friend",
+                            "hello my dog",
+                            "hello my cat"))
   hello_tbl <- testthat_tbl("hello")
 
   expect_equal(hello_tbl %>%
@@ -17,7 +17,7 @@ test_that("regex relational operators work", {
                  filter(grepl("cat", hello))
   )
 
-  products <- data_frame(
+  products <- tibble(
     product_id = 1:3,
     product_description = c("fruit", "Fruit", "milk"))
 

--- a/tests/testthat/test-dplyr-lead-lag.R
+++ b/tests/testthat/test-dplyr-lead-lag.R
@@ -4,8 +4,8 @@ sc <- testthat_spark_connection()
 
 test_that("lead and lag take numeric values for 'n' (#925)", {
   test_requires("dplyr")
-  example_df <- data_frame(ID = 1:10, Cat = rep(letters[1:5], 2),
-                          Numb = c(3, 10, NA, 5, 1, 6, NA, 4, NA, 8))
+  example_df <- tibble(ID = 1:10, Cat = rep(letters[1:5], 2),
+                       Numb = c(3, 10, NA, 5, 1, 6, NA, 4, NA, 8))
   example_df_tbl <- copy_to(sc, example_df, overwrite = TRUE)
 
   expect_equal(

--- a/tests/testthat/test-dplyr-stats.R
+++ b/tests/testthat/test-dplyr-stats.R
@@ -19,8 +19,8 @@ test_that("cor, cov, sd and var works as expected", {
     mutate(
       cor = cor(x, y),
       cov = cov(x, y),
-      sd = sd(x),
-      var = var(x)
+      sd = sd(x, na.rm = TRUE),
+      var = var(x, na.rm = TRUE)
     ) %>%
     collect() %>%
     as.data.frame()
@@ -50,8 +50,8 @@ test_that("cor, cov, sd and var works as expected over groups", {
     mutate(
       cor = cor(x, y),
       cov = cov(x, y),
-      sd = sd(x),
-      var = var(x)
+      sd = sd(x, na.rm = TRUE),
+      var = var(x, na.rm = TRUE)
     ) %>%
     arrange(id, x, y) %>%
     collect() %>%

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -5,8 +5,8 @@ sc <- testthat_spark_connection()
 iris_tbl <- testthat_tbl("iris")
 test_requires("dplyr")
 
-df1 <- data_frame(a = 1:3, b = letters[1:3])
-df2 <- data_frame(b = letters[1:3], c = letters[24:26])
+df1 <- tibble(a = 1:3, b = letters[1:3])
+df2 <- tibble(b = letters[1:3], c = letters[24:26])
 
 df1_tbl <- testthat_tbl("df1")
 df2_tbl <- testthat_tbl("df2")

--- a/tests/testthat/test-ml-classification-logistic-regression.R
+++ b/tests/testthat/test-ml-classification-logistic-regression.R
@@ -38,7 +38,7 @@ test_that("ml_logistic_regression() param setting", {
 test_that("ml_logistic_regression.tbl_spark() works properly", {
   sc <- testthat_spark_connection()
 
-  training <- data_frame(
+  training <- tibble(
     id = 0:3L,
     text = c("a b c d e spark",
              "b d",
@@ -46,7 +46,7 @@ test_that("ml_logistic_regression.tbl_spark() works properly", {
              "hadoop mapreduce"),
     label = c(1, 0, 1, 0)
   )
-  test <- data_frame(
+  test <- tibble(
     id = 4:7L,
     text = c("spark i j k", "l m n", "spark hadoop spark", "apache hadoop")
   )

--- a/tests/testthat/test-ml-feature-binarizer.R
+++ b/tests/testthat/test-ml-feature-binarizer.R
@@ -18,7 +18,7 @@ test_that("ft_binarizer() param setting", {
 
 test_that("ft_binarizer.tbl_spark() works", {
   sc <- testthat_spark_connection()
-  df <- data_frame(id = 0:2L, feature = c(0.1, 0.8, 0.2))
+  df <- tibble(id = 0:2L, feature = c(0.1, 0.8, 0.2))
   df_tbl <- copy_to(sc, df, overwrite = TRUE)
   expect_equal(
     df_tbl %>%

--- a/tests/testthat/test-ml-feature-count-vectorizer.R
+++ b/tests/testthat/test-ml-feature-count-vectorizer.R
@@ -24,7 +24,7 @@ test_that("ft_count_vectorizer() param setting", {
 test_that("ft_count_vectorizer() works", {
   test_requires_version("2.0.0", "features require Spark 2.0+")
   sc <- testthat_spark_connection()
-  df <- data_frame(text = c("a b c", "a a a b b c"))
+  df <- tibble(text = c("a b c", "a a a b b c"))
   df_tbl <- copy_to(sc, df, overwrite = TRUE)
 
   counts <- df_tbl %>%

--- a/tests/testthat/test-ml-feature-pca.R
+++ b/tests/testthat/test-ml-feature-pca.R
@@ -14,14 +14,14 @@ test_that("ft_pca() param setting", {
 
 test_that("ft_pca() works", {
   sc <- testthat_spark_connection()
-  mat <- data_frame(
+  mat <- dplyr::tibble(
     V1 = c(0, 2, 4),
     V2 = c(1, 0, 0),
     V3 = c(0, 3, 0),
     V4 = c(7, 4, 6),
     V5 = c(0, 5, 7))
 
-  s <- data_frame(
+  s <- dplyr::tibble(
     PC1 = c(1.6485728230883807, -4.645104331781534, -6.428880535676489),
     PC2 = c(-4.013282700516296, -1.1167972663619026, -5.337951427775355),
     PC3 = c(-5.524543751369388, -5.524543751369387, -5.524543751369389)

--- a/tests/testthat/test-ml-feature-quantile-discretizer.R
+++ b/tests/testthat/test-ml-feature-quantile-discretizer.R
@@ -31,7 +31,7 @@ test_that("ft_quantile_discretizer() param setting", {
 
 test_that("ft_quantile_discretizer works", {
   sc <- testthat_spark_connection()
-  df <- data_frame(
+  df <- tibble(
     id = 0:4L,
     hour = c(18, 19, 8, 5, 2)
   )
@@ -47,7 +47,7 @@ test_that("ft_quantile_discretizer works", {
 test_that("ft_quantile_discretizer works on multiple columns", {
   test_requires_version("2.3.0", comment = "multiple columns support requires spark 2.3+")
   sc <- testthat_spark_connection()
-  df <- data_frame(
+  df <- tibble(
     id = 0:4L,
     hour = c(18, 19, 8, 5, 2),
     hour2 = c(5, 2, 12, 6, 1)

--- a/tests/testthat/test-ml-feature-regex-tokenizer.R
+++ b/tests/testthat/test-ml-feature-regex-tokenizer.R
@@ -23,7 +23,7 @@ test_that("ft_regex_tokenizer() param setting", {
 
 test_that("ft_regex_tokenizer() works", {
   sc <- testthat_spark_connection()
-  sentence_df <- data_frame(
+  sentence_df <- tibble(
     id = c(0, 1, 2),
     sentence = c("Hi I heard about Spark",
                  "I wish Java could use case classes",

--- a/tests/testthat/test-ml-feature-stop-words-remover.R
+++ b/tests/testthat/test-ml-feature-stop-words-remover.R
@@ -24,8 +24,8 @@ test_that("ft_stop_words_remover() param setting", {
 test_that("ft_stop_words_remover() works", {
   test_requires_version("2.0.0", "loadDefaultStopWords requires Spark 2.0+")
   sc <- testthat_spark_connection()
-  df <- data_frame(id = c(0, 1),
-                   raw = c("I saw the red balloon", "Mary had a little lamb"))
+  df <- tibble(id = c(0, 1),
+               raw = c("I saw the red balloon", "Mary had a little lamb"))
   df_tbl <- copy_to(sc, df, overwrite = TRUE)
 
   expect_identical(

--- a/tests/testthat/test-ml-feature-string-indexer.R
+++ b/tests/testthat/test-ml-feature-string-indexer.R
@@ -32,7 +32,7 @@ test_that("ft_string_indexer() param setting", {
 
 test_that("ft_string_indexer() works", {
   sc <- testthat_spark_connection()
-  df <- dplyr::data_frame(string = c("foo", "bar", "foo", "foo"))
+  df <- dplyr::tibble(string = c("foo", "bar", "foo", "foo"))
   df_tbl <- dplyr::copy_to(sc, df, overwrite = TRUE)
 
   indexer <- ft_string_indexer(sc, "string", "indexed") %>%

--- a/tests/testthat/test-ml-persistence.R
+++ b/tests/testthat/test-ml-persistence.R
@@ -4,7 +4,7 @@ skip_databricks_connect()
 sc <- testthat_spark_connection()
 
 test_requires("dplyr")
-training <- data_frame(
+training <- tibble(
   id = 0:3L,
   text = c("a b c d e spark",
            "b d",
@@ -15,7 +15,7 @@ training <- data_frame(
 
 training_tbl <- testthat_tbl("training")
 
-test <- data_frame(
+test <- tibble(
   id = 4:7L,
   text = c("spark i j k", "l m n", "spark hadoop spark", "apache hadoop")
 )

--- a/tests/testthat/test-ml-pipeline.R
+++ b/tests/testthat/test-ml-pipeline.R
@@ -3,7 +3,7 @@ context("ml pipeline")
 skip_databricks_connect()
 sc <- testthat_spark_connection()
 
-training <- dplyr::data_frame(
+training <- dplyr::tibble(
   id = 0:3L,
   text = c("a b c d e spark",
            "b d",
@@ -14,7 +14,7 @@ training <- dplyr::data_frame(
 
 training_tbl <- testthat_tbl("training")
 
-test <- dplyr::data_frame(
+test <- dplyr::tibble(
   id = 4:7L,
   text = c("spark i j k", "l m n", "spark hadoop spark", "apache hadoop")
 )

--- a/tests/testthat/test-serialization.R
+++ b/tests/testthat/test-serialization.R
@@ -7,7 +7,7 @@ test_requires("nycflights13")
 flights_small <- flights %>% dplyr::sample_n(10000)
 flights_tbl <- testthat_tbl("flights_small")
 
-logical_nas <- data_frame(bools = c(T, NA, F))
+logical_nas <- tibble(bools = c(T, NA, F))
 logical_nas_tbl <- testthat_tbl("logical_nas")
 
 ensure_round_trip <- function(sc, data) {
@@ -85,7 +85,7 @@ test_that("data.frames with many columns don't cause Java StackOverflows", {
   version <- Sys.getenv("SPARK_VERSION", unset = "2.2.0")
 
   n <- if (version >= "2.0.0") 500 else 5000
-  df <- matrix(0, ncol = n, nrow = 2) %>% as_tibble()
+  df <- matrix(0, ncol = n, nrow = 2) %>% as_tibble(.name_repair = "unique")
   sdf <- copy_to(sc, df, overwrite = TRUE)
 
   # the above failed with a Java StackOverflow with older versions of sparklyr
@@ -149,7 +149,7 @@ test_that("collect() can retrieve all data types correctly", {
 
   arrow_compat <- using_arrow()
 
-  hive_type <- tibble::frame_data(
+  hive_type <- tibble::tribble(
     ~stype,            ~svalue,      ~rtype,     ~rvalue,      ~atype,     ~avalue,
     "tinyint",             "1",   "integer",         "1",   "integer",         "1",
     "smallint",            "1",   "integer",         "1",   "integer",         "1",
@@ -210,7 +210,7 @@ test_that("collect() can retrieve all data types correctly", {
 test_that("collect() can retrieve NULL data types as NAs", {
   library(dplyr)
 
-  hive_type <- tibble::frame_data(
+  hive_type <- tibble::tribble(
         ~stype,        ~rtype,        ~atype,
      "tinyint",     "integer",         "raw",
     "smallint",     "integer",     "integer",
@@ -336,9 +336,7 @@ test_that("collect() can retrieve as.POSIXct fields with timezones", {
 test_that("collect() can retrieve specific dates without timezones", {
   data_tbl <- sdf_copy_to(
     sc,
-    data_frame(
-      t = c(1419126103)
-    )
+    tibble(t = c(1419126103))
   )
 
   expect_equal(

--- a/tests/testthat/test-spark-apply-ext.R
+++ b/tests/testthat/test-spark-apply-ext.R
@@ -212,7 +212,7 @@ test_that("'spark_apply' can use anonymous functions", {
   skip_slow("takes too long to measure coverage")
   expect_equal(
     sdf_len(sc, 3) %>% spark_apply(~ .x + 1) %>% collect(),
-    data_frame(id = c(2, 3, 4))
+    tibble(id = c(2, 3, 4))
   )
 })
 


### PR DESCRIPTION
Functions deprecated:
```
dplyr::data_frame()
dplyr::data_frame_()
tibble::frame_data()
rlang::modify()
rlang::invoke()
```

missing parameters:

```
.repair_name = "unique"
na.rm = TRUE
```