### PR TITLE
fix typo in spark_write_avro documentation

### DIFF
--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -1052,7 +1052,7 @@ spark_read_avro <- function(sc,
 #' \code{spark_connect(..., packages = c("org.apache.spark:spark-avro_2.12:3.0.0-preview2", <other package(s)>), ...)}).
 #'
 #' @inheritParams spark_write_csv
-#" @param avro_schema Optional Avro schema in JSON format
+#' @param avro_schema Optional Avro schema in JSON format
 #' @param record_name Optional top level record name in write result (default: "topLevelRecord")
 #' @param record_namespace Record namespace in write result (default: "")
 #' @param compression Compression codec to use (default: "snappy")

--- a/man/sdf_from_avro.Rd
+++ b/man/sdf_from_avro.Rd
@@ -4,12 +4,17 @@
 \alias{sdf_from_avro}
 \title{Convert column(s) from avro format}
 \usage{
-sdf_from_avro(x, cols = colnames(x))
+sdf_from_avro(x, cols)
 }
 \arguments{
 \item{x}{An object coercible to a Spark DataFrame}
 
-\item{cols}{Subset of Columns to convert from avro format}
+\item{cols}{Named list of columns to transform from Avro format plus a valid Avro
+schema string for each column, where column names are keys and column schema strings
+are values (e.g.,
+\code{c(example_primitive_col = "string",
+example_complex_col = "{\"type\":\"record\",\"name\":\"person\",\"fields\":[
+{\"name\":\"person_name\",\"type\":\"string\"}, {\"name\":\"person_id\",\"type\":\"long\"}]}")}}
 }
 \description{
 Convert column(s) from avro format

--- a/man/spark_write_avro.Rd
+++ b/man/spark_write_avro.Rd
@@ -20,6 +20,8 @@ spark_write_avro(
 \item{path}{The path to the file. Needs to be accessible from the cluster.
 Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 
+\item{avro_schema}{Optional Avro schema in JSON format}
+
 \item{record_name}{Optional top level record name in write result (default: "topLevelRecord")}
 
 \item{record_namespace}{Record namespace in write result (default: "")}


### PR DESCRIPTION
Signed-off-by: yl790 <yitao@rstudio.com>