### PR TITLE
avoid unnecessary re-installation of R packages in CI workflow

### DIFF
--- a/ci/.ci.R
+++ b/ci/.ci.R
@@ -1,10 +1,16 @@
 args <- commandArgs(trailingOnly=TRUE)
 
+ensure_pkgs <- function(pkgs) {
+  for (pkg in pkgs)
+    if (!require(pkg))
+      install.packages(pkg)
+}
+
 if (length(args) == 0) {
   stop("Missing arguments")
 } else if (args[[1]] == "--install_pkgs") {
   if (package_version(paste(R.Version()$major, R.Version()$minor, sep = ".")) >= "3.3") {
-    install.packages("sparklyr.nested")
+    ensure_pkgs("sparklyr.nested")
   }
   parent_dir <- dir(".", full.names = TRUE)
   sparklyr_package <- parent_dir[grepl("sparklyr_", parent_dir)]
@@ -14,22 +20,21 @@ if (length(args) == 0) {
   setwd("tests")
   source("testthat.R")
 } else if (args[[1]] == "--coverage") {
-  install.packages("devtools")
+  ensure_pkgs("devtools")
 
   devtools::install_github("javierluraschi/covr", ref = "feature/no-batch")
   covr::codecov(type = "none", code = "setwd('tests'); source('testthat.R')", batch = FALSE)
 } else if (args[[1]] == "--arrow") {
-  install.packages("devtools")
+  ensure_pkgs("devtools")
 
   if (length(args) >= 2) {
-    devtools::install_github( "apache/arrow", subdir = "r", ref = args[2])
+    devtools::install_github("apache/arrow", subdir = "r", ref = args[2])
   }
   else {
-    devtools::install_github( "apache/arrow", subdir = "r")
+    devtools::install_github("apache/arrow", subdir = "r")
   }
 } else if (args[[1]] == "--verify-embedded-srcs") {
-  install.packages("diffobj")
-  install.packages("stringr")
+  ensure_pkgs(c("diffobj", "stringr"))
 
   sparklyr:::spark_verify_embedded_sources()
 }else {


### PR DESCRIPTION
I think we already cache those packages, but the CI script needs to be revised to not ignore the cached versions.

Signed-off-by: yl790 <yitao@rstudio.com>