### PR TITLE
update_embedded_sources.R should also sync java/embedded_sources.R

### DIFF
--- a/R/spark_update_embedded_sources.R
+++ b/R/spark_update_embedded_sources.R
@@ -11,6 +11,9 @@ spark_update_embedded_sources <- function(jars_to_skip = c()) {
   ensure_directory(srcs_dir)
   srcs <- file.path(srcs_dir, "embedded_sources.R")
   spark_gen_embedded_sources(output = srcs)
+  # apply the same update to all copies in sparklyr-*.jar and also to the copy
+  # inside java/ to avoid confusion
+  file.copy(from = srcs, to = file.path(pkg_root, "java"), overwrite = TRUE)
 
   sparklyr_jars <- list_sparklyr_jars()
 


### PR DESCRIPTION
Even though technically it only needs to sync the copies inside jar files, syncing java/embedded_sources.R as well would reduce the amount of confusion later on when java/embedded_sources.R needs to be modified by configure.R

Signed-off-by: yl790 <yitao@rstudio.com>