### PR TITLE
minor changes to test cases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ environment:
     R_VERSION: release
     USE_RTOOLS: true
     TEMP: "C:\\Users\\appveyor"
+    TZ: "UTC"
 
   matrix:
   - SPARK_VERSION: "1.6.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ init:
         $ErrorActionPreference = "Stop"
         Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
+        Set-TimeZone "GMT Standard Time"
 
 install:
   ps: Bootstrap

--- a/tests/testthat/test-serialization.R
+++ b/tests/testthat/test-serialization.R
@@ -269,10 +269,7 @@ test_that("collect() can retrieve date types successfully", {
   )
   expect_equal(
     as.list(df),
-    as.list(df %>% sdf_copy_to(sc, ., overwrite = TRUE) %>% sdf_collect()),
-    # conversion between non-UTC and UTC may create some small floating point
-    # rounding error due to Date being handled as floating point numbers in R
-    tolerance = 0.001
+    as.list(df %>% sdf_copy_to(sc, ., overwrite = TRUE) %>% sdf_collect())
   )
 })
 


### PR DESCRIPTION
- non-UTC time zone is not working well on Windows for some reason, even though perfectly fine on Linux and this will need more investigation
- I suspect we don't need `tolerance = ...` any more in `expect_equal` after previous change to avoid floating point error

Signed-off-by: yl790 <yitao@rstudio.com>