### PR TITLE
ensure additional sparklyr extension repositories are handled correctly

### DIFF
--- a/R/spark_extensions.R
+++ b/R/spark_extensions.R
@@ -92,7 +92,8 @@ spark_dependencies_from_extensions <- function(spark_version, extensions, config
     jars = jars,
     packages = packages,
     initializers = initializers,
-    catalog_jars = catalog_jars
+    catalog_jars = catalog_jars,
+    repositories = repositories
   )
 }
 


### PR DESCRIPTION
I'm probably the first person to have run into this. We should definitely include this fix in the 1.3 release.

Signed-off-by: yl790 <yitao@rstudio.com>