### PR TITLE
compare absolute errors instead of relative errors

### DIFF
--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -370,7 +370,7 @@ expect_coef_equal <- function(lhs, rhs) {
   lhs <- lhs[nm]
   rhs <- rhs[nm]
 
-  expect_true(all.equal(lhs, rhs, tolerance = 0.01))
+  expect_true(all.equal(lhs, rhs, tolerance = 0.01, scale = 1))
 }
 
 skip_on_arrow <- function() {

--- a/tests/testthat/test-broom-aft_survival_regression.R
+++ b/tests/testthat/test-broom-aft_survival_regression.R
@@ -19,7 +19,7 @@ test_that("aft_survival_regression.tidy() works", {
   check_tidy(td1, exp.row = 3, exp.col = 2,
              exp.names = c("features", "coefficients"))
   expect_equal(td1$coefficients, c(2.64, -0.496, 0.198),
-               tolerance = 0.001)
+               tolerance = 0.001, scale = 1)
 
 })
 

--- a/tests/testthat/test-broom-decision_tree.R
+++ b/tests/testthat/test-broom-decision_tree.R
@@ -13,7 +13,7 @@ test_that("decision_tree.tidy() works", {
 
   check_tidy(td1, exp.row = 2,
              exp.names = c("feature", "importance"))
-  expect_equal(td1$importance, c(0.94, 0.0603), tolerance = 0.001)
+  expect_equal(td1$importance, c(0.94, 0.0603), tolerance = 0.001, scale = 1)
 
   # for regression
   td2 <- iris_tbl %>%
@@ -22,7 +22,7 @@ test_that("decision_tree.tidy() works", {
 
   check_tidy(td2, exp.row = 2,
              exp.names = c("feature", "importance"))
-  expect_equal(td2$importance, c(0.954, 0.0456), tolerance = 0.001)
+  expect_equal(td2$importance, c(0.954, 0.0456), tolerance = 0.001, scale = 1)
 
 })
 

--- a/tests/testthat/test-broom-gradient_boosted_trees.R
+++ b/tests/testthat/test-broom-gradient_boosted_trees.R
@@ -22,11 +22,11 @@ test_that("gradient_boosted_trees.tidy() works", {
   check_tidy(td1, exp.row = 2,
              exp.names = c("feature", "importance"))
   if (spark_version(sc) < "3.0.0") {
-    expect_equal(get_importance(tbl = td1, "Petal_Length"), 0.594, tolerance = 0.05)
-    expect_equal(get_importance(tbl = td1, "Sepal_Length"), 0.406, tolerance = 0.05)
+    expect_equal(get_importance(tbl = td1, "Petal_Length"), 0.594, tolerance = 0.05, scale = 1)
+    expect_equal(get_importance(tbl = td1, "Sepal_Length"), 0.406, tolerance = 0.05, scale = 1)
   } else {
-    expect_equal(get_importance(tbl = td1, "Petal_Length"), 0.819, tolerance = 0.05)
-    expect_equal(get_importance(tbl = td1, "Sepal_Length"), 0.181, tolerance = 0.05)
+    expect_equal(get_importance(tbl = td1, "Petal_Length"), 0.819, tolerance = 0.05, scale = 1)
+    expect_equal(get_importance(tbl = td1, "Sepal_Length"), 0.181, tolerance = 0.05, scale = 1)
   }
 
   # for regression
@@ -37,11 +37,11 @@ test_that("gradient_boosted_trees.tidy() works", {
   check_tidy(td2, exp.row = 2,
              exp.names = c("feature", "importance"))
   if (spark_version(sc) < "3.0.0") {
-    expect_equal(get_importance(tbl = td2, "Petal_Length"), 0.607, tolerance = 0.001)
-    expect_equal(get_importance(tbl = td2, "Petal_Width"), 0.393, tolerance = 0.001)
+    expect_equal(get_importance(tbl = td2, "Petal_Length"), 0.607, tolerance = 0.001, scale = 1)
+    expect_equal(get_importance(tbl = td2, "Petal_Width"), 0.393, tolerance = 0.001, scale = 1)
   } else {
-    expect_equal(get_importance(tbl = td2, "Petal_Length"), 0.798, tolerance = 0.001)
-    expect_equal(get_importance(tbl = td2, "Petal_Width"), 0.202, tolerance = 0.001)
+    expect_equal(get_importance(tbl = td2, "Petal_Length"), 0.798, tolerance = 0.001, scale = 1)
+    expect_equal(get_importance(tbl = td2, "Petal_Width"), 0.202, tolerance = 0.001, scale = 1)
   }
 })
 

--- a/tests/testthat/test-broom-lda.R
+++ b/tests/testthat/test-broom-lda.R
@@ -25,7 +25,8 @@ test_that("lda.tidy() works", {
                ifelse(spark_version(sc) < "3.0.0",
                       list(c(0.8773, 0.9466, 1.2075)),
                       list(c(0.8790, 0.9478, 1.1515)))[[1]],
-               tolerance = 0.001)
+               tolerance = 0.001,
+               scale = 1)
 })
 
 test_that("lda.augment() works", {

--- a/tests/testthat/test-broom-linear_svc.R
+++ b/tests/testthat/test-broom-linear_svc.R
@@ -15,7 +15,7 @@ test_that("linear_svc.tidy() works", {
   check_tidy(td1, exp.row = 5, exp.col = 2,
              exp.names = c("features", "coefficients"))
   expect_equal(td1$coefficients, c(-4.55, -0.981, -2.85, 1.87, 6.06),
-               tolerance = 0.001)
+               tolerance = 0.01, scale = 1)
 
 })
 

--- a/tests/testthat/test-broom-logistic_regression.R
+++ b/tests/testthat/test-broom-logistic_regression.R
@@ -14,7 +14,7 @@ test_that("logistic_regression.tidy() works", {
   check_tidy(td1, exp.row = 3, exp.col = 4,
              exp.names = c("features", "versicolor_coef",
                            "virginica_coef", "setosa_coef"))
-  expect_equal(td1$versicolor_coef, c(15.26, -5.07, 7.7), tolerance = 0.001)
+  expect_equal(td1$versicolor_coef, c(15.26, -5.07, 7.7), tolerance = 0.01, scale = 1)
 
   # for binary classification
   td2 <- iris_tbl %>%
@@ -24,7 +24,7 @@ test_that("logistic_regression.tidy() works", {
 
   check_tidy(td2, exp.row = 3, exp.col = 2,
              exp.names = c("features", "coefficients"))
-  expect_equal(td2$coefficients, c(-39.8, -4.02, 13.3), tolerance = 0.001)
+  expect_equal(td2$coefficients, c(-39.84, -4.023, 13.31), tolerance = 0.01, scale = 1)
 
 })
 

--- a/tests/testthat/test-broom-multilayer_perceptron.R
+++ b/tests/testthat/test-broom-multilayer_perceptron.R
@@ -32,7 +32,7 @@ test_that("multilayer_perceptron.tidy() works", {
 
   expect_equal(td1$weight_matrix[[3]],
                matrix(expected_coeffs, nrow = 4, byrow = TRUE),
-               tolerance = 0.001)
+               tolerance = 0.001, scale = 1)
 
 })
 

--- a/tests/testthat/test-broom-naive_bayes.R
+++ b/tests/testthat/test-broom-naive_bayes.R
@@ -17,7 +17,7 @@ test_that("naive_bayes.tidy() works", {
   check_tidy(td1, exp.row = 3, exp.col = 4,
              exp.names = c(".label", "Sepal_Length",
                            "Petal_Length", ".pi"))
-  expect_equal(td1$Sepal_Length, c(-0.258, -0.542, -0.612), tolerance = 0.001)
+  expect_equal(td1$Sepal_Length, c(-0.258, -0.542, -0.612), tolerance = 0.001, scale = 1)
 
 })
 

--- a/tests/testthat/test-broom-pca.R
+++ b/tests/testthat/test-broom-pca.R
@@ -20,7 +20,7 @@ test_that("pca.tidy() works", {
 
   expect_equal(td1$PC1,
                -as.vector(model$rotation[,1]),
-               tolerance = 0.001)
+               tolerance = 0.001, scale = 1)
 
 })
 

--- a/tests/testthat/test-broom-random_forest.R
+++ b/tests/testthat/test-broom-random_forest.R
@@ -13,7 +13,7 @@ test_that("random_forest.tidy() works", {
 
   check_tidy(td1, exp.row = 2,
              exp.names = c("feature", "importance"))
-  expect_equal(td1$importance, c(0.941, 0.0586), tolerance = 0.1)
+  expect_equal(td1$importance, c(0.941, 0.0586), tolerance = 0.1, scale = 1)
 
   # for regression
   td2 <- iris_tbl %>%
@@ -22,7 +22,7 @@ test_that("random_forest.tidy() works", {
 
   check_tidy(td2, exp.row = 2,
              exp.names = c("feature", "importance"))
-  expect_equal(td2$importance, c(0.658, 0.342), tolerance = 0.1)
+  expect_equal(td2$importance, c(0.658, 0.342), tolerance = 0.1, scale = 1)
 
 })
 

--- a/tests/testthat/test-ml-classification-logistic-regression.R
+++ b/tests/testthat/test-ml-classification-logistic-regression.R
@@ -93,7 +93,7 @@ test_that("ml_logistic_regression() agrees with stats::glm()", {
                               formula = "versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
                               reg_param = 0L,
                               weight_col = "weights")
-  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5, scale = 1)
 
   r <- glm(versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
            family = binomial(logit), data = iris_weighted)
@@ -101,7 +101,7 @@ test_that("ml_logistic_regression() agrees with stats::glm()", {
                               formula = "versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
                               reg_param = 0L,
                               weight_col = "ones")
-  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5, scale = 1)
 })
 
 test_that("ml_logistic_regression can fit without intercept",{
@@ -117,7 +117,7 @@ test_that("ml_logistic_regression can fit without intercept",{
     formula = versicolor ~ Sepal_Width + Petal_Length + Petal_Width,
     fit_intercept=FALSE),NA)
   r <- glm(versicolor ~ Sepal.Width + Petal.Length + Petal.Width - 1, family=binomial(logit), data=iris_weighted)
-  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5, scale = 1)
 })
 
 test_that("ml_logistic_regression() agrees with stats::glm() for reversed categories", {
@@ -136,7 +136,7 @@ test_that("ml_logistic_regression() agrees with stats::glm() for reversed catego
                               formula = "versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
                               reg_param = 0L,
                               weight_col = "weights")
-  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5, scale = 1)
 
   r <- glm(versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
            family = binomial(logit), data = iris_weighted)
@@ -144,7 +144,7 @@ test_that("ml_logistic_regression() agrees with stats::glm() for reversed catego
                               formula = "versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
                               reg_param = 0L,
                               weight_col = "ones")
-  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5, scale = 1)
 })
 
 test_that("ml_logistic_regression.tbl_spark() takes both quoted and unquoted formulas", {
@@ -254,7 +254,7 @@ test_that("weights column works for logistic regression", {
                               features = c("Sepal_Width", "Petal_Length", "Petal_Width"),
                               reg_param = 0L,
                               weight_col = "weights")
-  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5, scale = 1)
 
   r <- glm(versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
            family = binomial(logit), data = iris_weighted)
@@ -263,7 +263,7 @@ test_that("weights column works for logistic regression", {
                               features = c("Sepal_Width", "Petal_Length", "Petal_Width"),
                               reg_param = 0L,
                               weight_col = "ones")
-  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5, scale = 1)
 })
 
 test_that("logistic regression bounds on coefficients", {

--- a/tests/testthat/test-ml-classification-naive-bayes.R
+++ b/tests/testthat/test-ml-classification-naive-bayes.R
@@ -70,7 +70,7 @@ test_that("ml_naive_bayes() and e1071::naiveBayes produce similar results", {
   Rp <- as.numeric(R$apriori / sum(R$apriori))
   Sp <- as.numeric(exp(model[["pi"]]))
 
-  expect_equal(Rp, Sp, tolerance = 0.001)
+  expect_equal(Rp, Sp, tolerance = 0.001, scale = 1)
 })
 
 test_that("ml_naive_bayes() print outputs are correct", {

--- a/tests/testthat/test-ml-clustering-kmeans-ext.R
+++ b/tests/testthat/test-ml-clustering-kmeans-ext.R
@@ -98,13 +98,13 @@ test_that("ml_compute_cost() for kmeans", {
   } else {
     expect_equal(
       ml_compute_cost(iris_kmeans, iris_tbl),
-      46.7123, tolerance = 0.01
+      46.7123, tolerance = 0.01, scale = 1
     )
     expect_equal(
       iris_tbl %>%
         ft_r_formula(~ . - Species) %>%
         ml_compute_cost(iris_kmeans$model, .),
-      46.7123, tolerance = 0.01
+      46.7123, tolerance = 0.01, scale = 1
     )
   }
 })

--- a/tests/testthat/test-ml-evaluate.R
+++ b/tests/testthat/test-ml-evaluate.R
@@ -167,7 +167,7 @@ test_that("ml_evaluate() works for kmeans", {
      ml_evaluate(iris_tbl)
 
   expect_equal(names(kmeans_silhouette), "Silhouette")
-  expect_equal(kmeans_silhouette$Silhouette, 0.85, tolerance = 0.001)
+  expect_equal(kmeans_silhouette$Silhouette, 0.85, tolerance = 0.001, scale = 1)
 })
 
 test_that("ml_evaluate() works for bisecting kmeans", {
@@ -178,7 +178,7 @@ test_that("ml_evaluate() works for bisecting kmeans", {
     ml_evaluate(iris_tbl)
 
   expect_equal(names(bi_kmeans_silhouette), "Silhouette")
-  expect_equal(bi_kmeans_silhouette$Silhouette, 0.517, tolerance = 0.001)
+  expect_equal(bi_kmeans_silhouette$Silhouette, 0.517, tolerance = 0.001, scale = 1)
 })
 
 test_that("ml_evaluate() works for gaussian mixtures model", {
@@ -189,7 +189,7 @@ test_that("ml_evaluate() works for gaussian mixtures model", {
     ml_evaluate(iris_tbl)
 
   expect_equal(names(gmm_silhouette), "Silhouette")
-  expect_equal(gmm_silhouette$Silhouette, 0.477, tolerance = 0.001)
+  expect_equal(gmm_silhouette$Silhouette, 0.477, tolerance = 0.001, scale = 1)
 })
 
 test_that("ml_evaluate() works for naive bayes model", {
@@ -199,7 +199,7 @@ test_that("ml_evaluate() works for naive bayes model", {
     ml_evaluate(iris_tbl)
 
   expect_equal(names(nb_acc), "Accuracy")
-  expect_equal(nb_acc$Accuracy, 0.953, tolerance = 0.001)
+  expect_equal(nb_acc$Accuracy, 0.953, tolerance = 0.001, scale = 1)
 })
 
 test_that("ml_evaluate() works for random forest model", {
@@ -258,5 +258,5 @@ test_that("ml_evaluate() works for svc model", {
     ml_evaluate(iris_tbl)
 
   expect_equal(names(svc_acc), "Accuracy")
-  expect_equal(svc_acc$Accuracy, 0.95, tolerance = 0.01)
+  expect_equal(svc_acc$Accuracy, 0.95, tolerance = 0.01, scale = 1)
 })

--- a/tests/testthat/test-ml-evaluation-clustering.R
+++ b/tests/testthat/test-ml-evaluation-clustering.R
@@ -12,7 +12,8 @@ test_that("ml_clustering_evaluator() works", {
   expect_equal(
     ml_clustering_evaluator(predictions),
     0.999753,
-    tolerance = 1e-5
+    tolerance = 1e-5,
+    scale = 1
   )
 })
 

--- a/tests/testthat/test-ml-feature-standard-scaler.R
+++ b/tests/testthat/test-ml-feature-standard-scaler.R
@@ -37,7 +37,7 @@ test_that("ft_standard_scaler() works properly", {
       dplyr::pull(scaledFeatures) %>%
       unlist() %>%
       sum(),
-    295.3425, tolerance = 0.001
+    295.3425, tolerance = 0.001, scale = 1
   )
 
   expect_output_file(

--- a/tests/testthat/test-ml-regression-survival-regression.R
+++ b/tests/testthat/test-ml-regression-survival-regression.R
@@ -39,24 +39,24 @@ test_that("ml_aft_survival_regression() works properly", {
   aft <- ml_aft_survival_regression(training_tbl, quantile_probabilities = list(0.3, 0.6),
                              quantiles_col = "quantiles")
 
-  expect_equal(aft$coefficients, c(-0.49631114666506776, 0.19844437699934067), tolerance = 1e-4)
-  expect_equal(aft$intercept, 2.6380946151040043, tolerance = 1e-4)
-  expect_equal(aft$scale, 1.5472345574364683, tolerance = 1e-4)
+  expect_equal(aft$coefficients, c(-0.49631114666506776, 0.19844437699934067), tolerance = 1e-4, scale = 1)
+  expect_equal(aft$intercept, 2.6380946151040043, tolerance = 1e-4, scale = 1)
+  expect_equal(aft$scale, 1.5472345574364683, tolerance = 1e-4, scale = 1)
 
   predicted_tbl <- ml_predict(aft, training_tbl)
   expect_equal(predicted_tbl %>%
                  dplyr::pull(quantiles) %>%
                  dplyr::first(),
                c(1.1603238947151593, 4.995456010274735),
-               tolerance = 1e-4)
+               tolerance = 1e-4, scale = 1)
   expect_equal(predicted_tbl %>%
                  dplyr::pull(prediction) %>%
                  dplyr::first(),
-               5.718979487634966, tolerance = 1e-4)
+               5.718979487634966, tolerance = 1e-4, scale = 1)
 
   aft_model <- ml_aft_survival_regression(training_tbl, label ~ V1 + V2, features_col = "feat")
   expect_equal(coef(aft_model),
                structure(c(2.63808989630564, -0.496304411053117, 0.198452172529228
                ), .Names = c("(Intercept)", "V1", "V2")),
-               tolerance = 1e-05)
+               tolerance = 1e-05, scale = 1)
 })

--- a/tests/testthat/test-ml-supervised-random-forest.R
+++ b/tests/testthat/test-ml-supervised-random-forest.R
@@ -112,7 +112,8 @@ test_that("one-tree forest agrees with ml_decision_tree()", {
                dt %>%
                  ml_predict(iris_tbl) %>%
                  collect(),
-               tolerance = 0.05)
+               tolerance = 0.5,
+               scale = 1)
 })
 
 test_that("checkpointing works for rf", {

--- a/tests/testthat/test-ml-tree-feature-importances.R
+++ b/tests/testthat/test-ml-tree-feature-importances.R
@@ -18,7 +18,7 @@ test_that("ml_tree_feature_importance() works properly", {
   dt_importance <- ml_tree_feature_importance(dt)
   expect_equal(colnames(rf_importance), c("feature", "importance"))
   expect_equal(nrow(rf_importance), 3)
-  expect_equal(rf_importance, dt_importance, tolerance = 0.025)
+  expect_equal(rf_importance, dt_importance, tolerance = 0.025, scale = 1)
 })
 
 test_that("ml_tree_feature_importance() works for decision tree classification", {


### PR DESCRIPTION
Because `expect_equal(x, y, tolerance = <epsilon>)` is in most cases checking magnitude of *relative error*, whereas `expect_equal(x, y, tolerance = <max_tolerable_abs_diff>, scale = 1)` will check absolute error (see `?all.equal` for details)

For example, `expect_equal(20, 18, tolerance = 0.1)` => no error reported, because 18 is still within 10% margin of error from 20 whereas `expect_equal(20, 18, tolerance = 0.1, scale = 1)` => error reported because 18 is more than 0.1 away from 20

I shall boldly assume all `expect_equal(x, y, tolerance = <tol>)` incantations are in fact supposed to check for absolute errors (and therefore creating this PR that just appends the required `scale = 1` arg everywhere -- as `scale = 1` to check for absolute error is **not** the default mode of `expect_equal`). If any of these checks are supposed to be checking for relative errors, please suggest change on this PR as soon as possible. 

Signed-off-by: yl790 <yitao@rstudio.com>