### PR TITLE
fix a bug with ordering of `.x` and `.y` parameters for lambda expression specified with a R formula in hof_* methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# Sparklyr 1.3.0.9000
+
+### Distributed R
+
+- Fixed a bug in ordering of parameters for a lamba expression when the lambda
+  expression passed to a `hof_*` method is specified with a R formula and the
+  lambda takes 2 parameters
+
 # Sparklyr 1.3.0
 
 ### Spark ML

--- a/R/dplyr_hof.R
+++ b/R/dplyr_hof.R
@@ -20,7 +20,7 @@ translate_formula <- function(f) {
   # renaming variables because Spark SQL cannot handle lambda variable name
   # starting with '.'
   f <- do.call(substitute, list(f, list(.x = var_x, .y = var_y)))
-  vars <- all.vars(f)
+  vars <- sort(all.vars(f))
   params_sql <- (
     if (length(vars) > 1)
       paste0("(", paste0(vars, collapse = ", "), ")")

--- a/tests/testthat/test-dplyr-hof.R
+++ b/tests/testthat/test-dplyr-hof.R
@@ -325,12 +325,12 @@ test_that("'hof_aggregate' works with default args", {
   test_requires_version("2.4.0")
 
   agg <- single_col_tbl %>%
-    hof_aggregate("", ~ CONCAT(.y, .x), ~ CONCAT("(", .x, ")")) %>%
+    hof_aggregate("-", ~ CONCAT(.y, .x), ~ CONCAT("(", .x, ")")) %>%
     sdf_collect()
 
   expect_equivalent(
     agg,
-    tibble::tibble(x = c("(12345)", "(678910)"))
+    tibble::tibble(x = c("(54321-)", "(109876-)"))
   )
 })
 


### PR DESCRIPTION
Signed-off-by: yl790 <yitao@rstudio.com>