### PR TITLE
fix a subtle bug in do_spark

### DIFF
--- a/R/do_spark.R
+++ b/R/do_spark.R
@@ -81,7 +81,7 @@ registerDoSpark <- function(spark_conn, ...) {
         enclos <- envir
         expr_globals <- as.list(expr_globals)
         for (k in names(expr_globals)) {
-          v <- expr_globals$k
+          v <- expr_globals[[k]]
           if (identical(typeof(v), "closure")) {
             # to make `enclos` truly self-contained, each of its element that is
             # a closure will need to have its enclosing environment replaced with

--- a/tests/testthat/test-do-spark.R
+++ b/tests/testthat/test-do-spark.R
@@ -86,5 +86,10 @@ test_that("doSpark works for loop with arbitrary R objects with multicombine", {
 })
 
 test_that("doSpark works for loop referencing external functions and variables", {
+  n <- 5
+  expect_equal(
+    unlist(foreach(x = 1:5) %dopar% { n * x }),
+    n * seq(5)
+  )
   foreach(x = 1:20, .combine = list) %test% quote(fn_2(list(x, y, z, fn_3(x)(y), fn_4(x))))
 })


### PR DESCRIPTION
A down-side of using non-standard evaluation in R is there can be weird bugs that will only surface under oddly specific set of circumstances.

Signed-off-by: yl790 <yitao@rstudio.com>