### PR TITLE
create spark_connect options for RAPIDS accelerator plugin

### DIFF
--- a/R/config_spark.R
+++ b/R/config_spark.R
@@ -130,10 +130,11 @@ spark_config_value_retries <- function(config, name, default, retries) {
 #' @param packages A list of named packages or versioned packagese to add.
 #' @param version The version of Spark being used.
 #' @param scala_version Acceptable Scala version of packages to be loaded
+#' @param ... Additional configurations
 #'
 #' @keywords interenal
 #' @export
-spark_config_packages <- function(config, packages, version, scala_version = NULL) {
+spark_config_packages <- function(config, packages, version, scala_version = NULL, ...) {
   version <- spark_version_latest(version)
 
   if ("kafka" %in% packages) {
@@ -175,6 +176,46 @@ spark_config_packages <- function(config, packages, version, scala_version = NUL
       config$sparklyr.shell.packages,
       spark_avro_package_name(version, scala_version)
     )
+  }
+
+  if ("rapids" %in% packages) {
+    packages <- packages[-which(packages == "rapids")]
+
+    if (version < "3.0.0")
+      stop("RAPIDS library is only supported in Spark 3.0.0 or higher")
+
+    additional_configs <- list(...)
+    config$sparklyr.shell.packages <- c(
+      config$sparklyr.shell.packages,
+      (
+        if (additional_configs$method %in% c("databricks", "databricks-connect"))
+          "com.nvidia:rapids-4-spark_2.12:0.1.0-databricks"
+        else
+          "com.nvidia:rapids-4-spark_2.12:0.1.0"
+      ),
+      "ai.rapids:cudf:0.14"
+    )
+
+    rapids_configs <- list(
+      spark.rapids.sql.incompatibleOps.enabled = "true"
+    )
+    rapids_prefix <- "spark.rapids."
+    additional_rapids_configs <- connection_config(
+      sc = list(config = config),
+      prefix = rapids_prefix
+    )
+    config <- append(
+      config,
+      list(sparklyr.shell.conf = "spark.plugins=com.nvidia.spark.SQLPlugin")
+    )
+    for (idx in seq_along(additional_rapids_configs)) {
+      k <- names(additional_rapids_configs)[[idx]]
+      v <- additional_rapids_configs[[idx]]
+      config <- append(
+        config,
+        list(sparklyr.shell.conf = paste0(rapids_prefix, k, "=", v))
+      )
+    }
   }
 
   if (!is.null(packages)) {

--- a/R/config_spark.R
+++ b/R/config_spark.R
@@ -196,21 +196,20 @@ spark_config_packages <- function(config, packages, version, scala_version = NUL
       "ai.rapids:cudf:0.14"
     )
 
-    rapids_configs <- list(
-      spark.rapids.sql.incompatibleOps.enabled = "true"
-    )
     rapids_prefix <- "spark.rapids."
-    additional_rapids_configs <- connection_config(
+    rapids_configs <- connection_config(
       sc = list(config = config),
       prefix = rapids_prefix
     )
+    rapids_configs[["sql.incompatibleOps.enabled"]] <-
+      rapids_configs[["sql.incompatibleOps.enabled"]] %||% "true"
     config <- append(
       config,
       list(sparklyr.shell.conf = "spark.plugins=com.nvidia.spark.SQLPlugin")
     )
-    for (idx in seq_along(additional_rapids_configs)) {
-      k <- names(additional_rapids_configs)[[idx]]
-      v <- additional_rapids_configs[[idx]]
+    for (idx in seq_along(rapids_configs)) {
+      k <- names(rapids_configs)[[idx]]
+      v <- rapids_configs[[idx]]
       config <- append(
         config,
         list(sparklyr.shell.conf = paste0(rapids_prefix, k, "=", v))

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -86,10 +86,10 @@ spark_config_shell_args <- function(config, master) {
   shell_args <- connection_config(config_sc, "sparklyr.shell.")
 
   # flatten shell_args to make them compatible with sparklyr
-  unlist(lapply(names(shell_args), function(name) {
-    lapply(shell_args[[name]], function(value) {
-      list(paste0("--", name), value)
-    })
+  unlist(lapply(seq_along(shell_args), function(idx) {
+    name <- names(shell_args)[[idx]]
+    value <- shell_args[[idx]]
+    list(paste0("--", name), value)
   }))
 }
 
@@ -158,7 +158,8 @@ spark_connect <- function(master,
       config,
       packages,
       version %||% spark_version_from_home(spark_home),
-      scala_version
+      scala_version,
+      method = method
     )
 
   if (is.null(spark_home) || !nzchar(spark_home)) spark_home <- spark_config_value(config, "spark.home", "")

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -80,6 +80,9 @@ spark_master_local_cores <- function(master, config) {
 }
 
 spark_config_shell_args <- function(config, master) {
+  if (!is.null(config$sparklyr.shell.packages))
+    config$sparklyr.shell.packages <- paste0(config$sparklyr.shell.packages, collapse = ",")
+
   # determine shell_args (use fake connection b/c we don't yet
   # have a real connection)
   config_sc <- list(config = config, master = master)

--- a/R/spark_connection.R
+++ b/R/spark_connection.R
@@ -118,46 +118,36 @@ spark_connection.spark_jobj <- function(x, ...) {
 #'
 #' @export
 connection_config <- function(sc, prefix, not_prefix = list()) {
-
   config <- sc$config
   master <- sc$master
   isLocal <- spark_master_is_local(master)
 
-  configNames <- Filter(function(e) {
-    found <- is.null(prefix) ||
-      (substring(e, 1, nchar(prefix)) == prefix)
+  isApplicable <- unlist(lapply(
+    seq_along(config),
+    function(idx) {
+      config_name <- names(config)[[idx]]
 
-    if (grepl("\\.local$", e) && !isLocal)
-      found <- FALSE
+      (is.null(prefix) || identical(substring(config_name, 1, nchar(prefix)), prefix)) &&
+      all(unlist(
+        lapply(not_prefix, function(x) !identical(substring(config_name, 1, nchar(x)), x))
+      )) &&
+      !(grepl("\\.local$", config_name) && !isLocal) &&
+      !(grepl("\\.remote$", config_name) && isLocal) &&
+      !(is.character(config[[idx]]) && all(nchar(config[[idx]]) == 0))
+    }
+  ))
+  configNames <- lapply(
+    names(config)[isApplicable],
+    function(configName) {
+      configName %>%
+        substr(nchar(prefix) + 1, nchar(configName)) %>%
+        sub("(\\.local$)|(\\.remote$)", "", ., perl = TRUE)
+    }
+  )
+  configValues <- config[isApplicable]
+  names(configValues) <- configNames
 
-    if (grepl("\\.remote$", e) && isLocal)
-      found <- FALSE
-
-    if (is.character(config[[e]]) && all(nchar(config[[e]]) == 0))
-      found <- FALSE
-
-    found
-  }, names(config))
-
-  lapply(not_prefix, function(notPrefix) {
-    configNames <<- Filter(function(e) {
-      substring(e, 1, nchar(notPrefix)) != notPrefix
-    }, configNames)
-  })
-
-  paramsNames <- lapply(configNames, function(configName) {
-    paramName <- substr(configName, nchar(prefix) + 1, nchar(configName))
-    paramName <- sub("(\\.local$)|(\\.remote$)", "", paramName, perl = TRUE)
-
-    paramName
-  })
-
-  params <- lapply(configNames, function(configName) {
-    config[[configName]]
-  })
-
-  names(params) <- paramsNames
-  params
+  configValues
 }
 
 #' View Entries in the Spark Log

--- a/man/spark_config_packages.Rd
+++ b/man/spark_config_packages.Rd
@@ -4,7 +4,7 @@
 \alias{spark_config_packages}
 \title{Creates Spark Configuration}
 \usage{
-spark_config_packages(config, packages, version, scala_version = NULL)
+spark_config_packages(config, packages, version, scala_version = NULL, ...)
 }
 \arguments{
 \item{config}{The Spark configuration object.}
@@ -14,6 +14,8 @@ spark_config_packages(config, packages, version, scala_version = NULL)
 \item{version}{The version of Spark being used.}
 
 \item{scala_version}{Acceptable Scala version of packages to be loaded}
+
+\item{...}{Additional configurations}
 }
 \description{
 Creates Spark Configuration

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -63,11 +63,12 @@ test_that("spark_config_shell_args() works as expected", {
   config <- list(
     sparklyr.shell.conf = "key1=value1",
     sparklyr.shell.conf = "key2=value2",
-    sparklyr.shell.key3 = "value3"
+    sparklyr.shell.key3 = "value3",
+    sparklyr.shell.packages = c("pkg1", "pkg2", "pkg3")
   )
 
   expect_equal(
     spark_config_shell_args(config = config, master = "local"),
-    c("--conf", "key1=value1", "--conf", "key2=value2", "--key3", "value3")
+    c("--conf", "key1=value1", "--conf", "key2=value2", "--key3", "value3", "--packages", "pkg1,pkg2,pkg3")
   )
 })

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -58,3 +58,16 @@ test_that("spark_config() can load from options", {
     10
   )
 })
+
+test_that("spark_config_shell_args() works as expected", {
+  config <- list(
+    sparklyr.shell.conf = "key1=value1",
+    sparklyr.shell.conf = "key2=value2",
+    sparklyr.shell.key3 = "value3"
+  )
+
+  expect_equal(
+    spark_config_shell_args(config = config, master = "local"),
+    c("--conf", "key1=value1", "--conf", "key2=value2", "--key3", "value3")
+  )
+})


### PR DESCRIPTION
@falaki  I noticed there also appears to be some Databricks-specific fork of rapids-4-spark_2.12, so presumably that means we shall have the following:

```
    packages <- c(
      packages,
      (
        if (method %in% c("databricks", "databricks-connect"))
          "com.nvidia:rapids-4-spark_2.12:0.1.0-databricks"
        else
          "com.nvidia:rapids-4-spark_2.12:0.1.0"
      ),
      "ai.rapids:cudf:0.14"
    )
```

Signed-off-by: yl790 <yitao@rstudio.com>