### PR TITLE
fix an issue with locating Livy jar file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,14 @@ jobs:
               SPARK_VERSION: '2.3.0'
               JAVA_VERSION: 'oraclejdk8'
               SPARKLYR_LIVY_BRANCH: 'feature/sparklyr-1.3.0'
+          - name: 'Livy 0.5.0 (R release, oraclejdk8, Spark 2.4.0)'
+            r: 'release'
+            env:
+              ARROW_ENABLED: 'false'
+              LIVY_VERSION: '0.5.0'
+              SPARK_VERSION: '2.4.0'
+              JAVA_VERSION: 'oraclejdk8'
+              SPARKLYR_LIVY_BRANCH: 'feature/sparklyr-1.3.0'
           - name: 'Arrow (release)'
             r: 'release'
             env:


### PR DESCRIPTION
- Ensure only 1 jar file is selected in presence of multiple supported scala versions
- Create another CI workflow for Livy + Spark 2.4

Signed-off-by: yl790 <yitao@rstudio.com>