### PR TITLE
avoid spark_read_compat_param name collision

### DIFF
--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -1,29 +1,28 @@
 #' @include avro_utils.R
 #' @include spark_apply.R
 
+gen_sdf_name <- function(path, config) {
+  path %>%
+    basename() %>%
+    tools::file_path_sans_ext() %>%
+    spark_sanitize_names(config) %>%
+    random_string()
+}
+
 # This function handles backward compatibility to support
 # unnamed datasets while not breaking sparklyr 0.9 param
 # signature. Returns a c(name, path) tuple.
 spark_read_compat_param <- function(sc, name, path) {
   if (is.null(name) && is.null(path)) {
     stop("The 'path' parameter must be specified.")
-  }
-  else if (identical(name, path)) {
+  } else if (identical(name, path)) {
     # This is an invalid use case, for 'spark_read_*(sc, "hello")';
     # however, for convenience and backwards compatibility we allow
     # to use the second parameter as the path.
-    c(
-      spark_sanitize_names(tools::file_path_sans_ext(basename(name)), sc$config),
-      name
-    )
-  }
-  else if (identical(name, NULL)) {
-    c(
-      spark_sanitize_names(tools::file_path_sans_ext(basename(path)), sc$config),
-      path
-    )
-  }
-  else {
+    c(gen_sdf_name(name, sc$config), name)
+  } else if (identical(name, NULL)) {
+    c(gen_sdf_name(path, sc$config), path)
+  } else {
     c(name, path)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,7 +28,7 @@ transpose_list <- function(list) {
 #' @param prefix A length-one character vector.
 #' @export
 random_string <- function(prefix = "table") {
-  basename(tempfile(prefix))
+  paste0(prefix, "_", gsub("-", "_", uuid::UUIDgenerate()))
 }
 
 printf <- function(fmt, ...) {


### PR DESCRIPTION
Append uuid to name <- basename(path) in `spark_read_compat_param()` so that reading from 2 different paths with the same basename does not cause one resulting data frame to overwrite the other

Signed-off-by: yl790 <yitao@rstudio.com>