### PR TITLE
make Spark SQL higher-order functions usable from within `dplyr::mutate` & co

### DIFF
--- a/R/dplyr_hof.R
+++ b/R/dplyr_hof.R
@@ -8,7 +8,7 @@ NULL
 
 # throw an error if f is not a valid lambda expression
 validate_lambda <- function(f) {
-  if (!"spark_sql_lambda" %in% class(f) && !"formula" %in% class(f)) {
+  if (!"spark_sql_lambda" %in% class(f) && !rlang::is_formula(f)) {
     stop(
       "Expected 'f' to be a lambda expression (e.g., 'a %->% (a + 1)' or ",
       "'.(a, b) %->% (a + b + 1)') or a formula (e.g., '~ .x + 1' or ",


### PR DESCRIPTION
A small improvement on the status quo: turns out we can also make `sdf %>% dplyr::mutate(squares = transform(arr, ~ .x * .x))` work, which is a bit more readable that the `hof_transform(dest_col = squares, ...)` syntax from sparklyr 1.3.

Signed-off-by: Yitao Li <yitao@rstudio.com>