### PR TITLE
sdf_quantile() handles multiple columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ tests/testthat/test\.json
 tests/testthat/batch\.csv/
 tests/testthat/iris-in/
 tests/testthat/iris-out/
+.Rproj.user

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,8 @@
 
 - Revised `spark_read_compat_param` to avoid collision on names assigned to
   different Spark data frames
+  
+- `sdf_quantile()` now supports calculation for multiple columns.
 
 ### Misc
 

--- a/man/sdf_quantile.Rd
+++ b/man/sdf_quantile.Rd
@@ -14,7 +14,8 @@ sdf_quantile(
 \arguments{
 \item{x}{A \code{spark_connection}, \code{ml_pipeline}, or a \code{tbl_spark}.}
 
-\item{column}{The column for which quantiles should be computed.}
+\item{column}{The column(s) for which quantiles should be computed.
+Multiple columns are only supported in Spark 2.0+.}
 
 \item{probabilities}{A numeric vector of probabilities, for
 which quantiles should be computed.}

--- a/tests/testthat/test-sdf-stat.R
+++ b/tests/testthat/test-sdf-stat.R
@@ -10,7 +10,7 @@ test_that("sdf_crosstab() works", {
   expect_setequal(df[, 1, drop = TRUE], c("8.0", "4.0", "6.0"))
 })
 
-test_that("sdf_quantile() works", {
+test_that("sdf_quantile() works for a single column", {
   sc <- testthat_spark_connection()
   mtcars_tbl <- testthat_tbl("mtcars")
   quantiles <- mtcars_tbl %>%
@@ -23,6 +23,13 @@ test_that("sdf_quantile() works", {
                     `75%` = 318,
                     `100%` = 472
                   ))
+
+})
+
+test_that("sdf_quantile() works for multiple column", {
+  sc <- testthat_spark_connection()
+  test_requires_version("2.0.0", "multicolumn quantile requires 2.0+")
+  mtcars_tbl <- testthat_tbl("mtcars")
 
   quantiles <- mtcars_tbl %>%
     sdf_quantile(column = c("disp", "drat"))

--- a/tests/testthat/test-sdf-stat.R
+++ b/tests/testthat/test-sdf-stat.R
@@ -11,6 +11,8 @@ test_that("sdf_crosstab() works", {
 })
 
 test_that("sdf_quantile() works for a single column", {
+  test_requires_version("2.0.0", "approxQuantile() is only supported in Spark 2.0.0 or above")
+
   sc <- testthat_spark_connection()
   mtcars_tbl <- testthat_tbl("mtcars")
   quantiles <- mtcars_tbl %>%

--- a/tests/testthat/test-sdf-stat.R
+++ b/tests/testthat/test-sdf-stat.R
@@ -9,3 +9,38 @@ test_that("sdf_crosstab() works", {
   expect_setequal(names(df), c("cyl_gear", "3.0", "4.0", "5.0"))
   expect_setequal(df[, 1, drop = TRUE], c("8.0", "4.0", "6.0"))
 })
+
+test_that("sdf_quantile() works", {
+  sc <- testthat_spark_connection()
+  mtcars_tbl <- testthat_tbl("mtcars")
+  quantiles <- mtcars_tbl %>%
+    sdf_quantile(column = "disp")
+  expect_mapequal(quantiles,
+                  c(
+                    `0%` = 71.1,
+                    `25%` = 120.3,
+                    `50%` = 167.6,
+                    `75%` = 318,
+                    `100%` = 472
+                  ))
+
+  quantiles <- mtcars_tbl %>%
+    sdf_quantile(column = c("disp", "drat"))
+  expect_named(quantiles, c("disp", "drat"))
+  expect_mapequal(quantiles[["disp"]],
+                  c(
+                    `0%` = 71.1,
+                    `25%` = 120.3,
+                    `50%` = 167.6,
+                    `75%` = 318,
+                    `100%` = 472
+                  ))
+  expect_mapequal(quantiles[["drat"]],
+                  c(
+                    `0%` = 2.76,
+                    `25%` = 3.08,
+                    `50%` = 3.69,
+                    `75%` = 3.92,
+                    `100%` = 4.93
+                  ))
+})


### PR DESCRIPTION
Allow a vector (or list) of columns to be passed to the `column` argument in `sdf_quantile()`.

The only thing I am unsure about is the minimum required Spark version. I have seen reference to anywhere from [2.0+](https://www.thetopsites.net/article/52173333.shtml) to [2.2](https://issues.apache.org/jira/browse/SPARK-14352). The first time it is mentioned in the official release notes (from what I can tell) is [2.2.0](https://spark.apache.org/releases/spark-release-2-2-0.html#sparkr), but that only references the `sparkR` implementation and not the underlying Spark implementation. I have set the function to require Spark >= 2.0.0 (when more than 1 column is provided), but can change it to >= 2.2.0 if you think that would be preferable. 