### PR TITLE
Avoiding bundle file name collision when session_id is not provided

### DIFF
--- a/R/spark_apply_bundle.R
+++ b/R/spark_apply_bundle.R
@@ -69,7 +69,6 @@ spark_apply_bundle_file <- function(packages, base_path, session_id) {
 spark_apply_bundle <- function(packages = TRUE, base_path = getwd(), session_id = NULL) {
   # If session_id is not provied use a random string to avoid file name collision.
   session_id <- session_id %||% uuid::UUIDgenerate(use.time = TRUE)
-  }
 
   packages <- if (is.character(packages)) spark_apply_packages(packages) else packages
 

--- a/R/spark_apply_bundle.R
+++ b/R/spark_apply_bundle.R
@@ -68,12 +68,7 @@ spark_apply_bundle_file <- function(packages, base_path, session_id) {
 #' @export
 spark_apply_bundle <- function(packages = TRUE, base_path = getwd(), session_id = NULL) {
   # If session_id is not provied use a random string to avoid file name collision.
-  if (is.null(session_id)) {
-    session_id <- substr(
-      digest::digest(paste(Sys.time(), collapse = "-"), algo = "sha256"),
-      start = 1,
-      stop = 7
-    )
+  session_id <- session_id %||% uuid::UUIDgenerate(use.time = TRUE)
   }
 
   packages <- if (is.character(packages)) spark_apply_packages(packages) else packages

--- a/R/spark_apply_bundle.R
+++ b/R/spark_apply_bundle.R
@@ -35,7 +35,7 @@ spark_apply_bundle_path <- function() {
   file.path(tempdir(), "packages")
 }
 
-spark_apply_bundle_file <- function(packages, base_path, session_id = NULL) {
+spark_apply_bundle_file <- function(packages, base_path, session_id) {
   file.path(
     base_path,
     if (isTRUE(packages)) {
@@ -67,6 +67,14 @@ spark_apply_bundle_file <- function(packages, base_path, session_id = NULL) {
 #'
 #' @export
 spark_apply_bundle <- function(packages = TRUE, base_path = getwd(), session_id = NULL) {
+  # If session_id is not provied use a random string to avoid file name collision.
+  if (is.null(session_id)) {
+    session_id <- digest::digest(paste(Sys.time(), collapse = "-"), algo = "sha256"),
+      start = 1,
+      stop = 7
+    )
+  }
+
   packages <- if (is.character(packages)) spark_apply_packages(packages) else packages
 
   packagesTar <- spark_apply_bundle_file(packages, base_path, session_id)

--- a/R/spark_apply_bundle.R
+++ b/R/spark_apply_bundle.R
@@ -69,7 +69,8 @@ spark_apply_bundle_file <- function(packages, base_path, session_id) {
 spark_apply_bundle <- function(packages = TRUE, base_path = getwd(), session_id = NULL) {
   # If session_id is not provied use a random string to avoid file name collision.
   if (is.null(session_id)) {
-    session_id <- digest::digest(paste(Sys.time(), collapse = "-"), algo = "sha256"),
+    session_id <- substr(
+      digest::digest(paste(Sys.time(), collapse = "-"), algo = "sha256"),
       start = 1,
       stop = 7
     )


### PR DESCRIPTION
When `session_id` is not passed to `spark_apply_bundle()` use a random hash instead of `session_id`