### PR TITLE
migrate from 'master' with 'main' in jenkins config file

### DIFF
--- a/ci/jenkins/test sparklyr on databricks.r
+++ b/ci/jenkins/test sparklyr on databricks.r
@@ -12,7 +12,7 @@ capture.output(
       {
         dbutils.widgets.removeAll()
         dbutils.widgets.text("Github repo", "sparklyr/sparklyr")
-        dbutils.widgets.text("Commit ref", "master")
+        dbutils.widgets.text("Commit ref", "main")
 
         print(dbutils.widgets.get("Github repo"))
         print(dbutils.widgets.get("Commit ref"))


### PR DESCRIPTION
We need to eventually migrate the default branch of `sparklyr` from 'master' to 'main'.

Signed-off-by: Yitao Li <yitao@rstudio.com>