### PR TITLE
make `dbQuoteIdentifier` handle NULL input correctly

### DIFF
--- a/R/dbi_spark_connection.R
+++ b/R/dbi_spark_connection.R
@@ -55,11 +55,15 @@ dbi_ensure_no_backtick <- function(x) {
 }
 
 setMethod("dbQuoteIdentifier", c("spark_connection", "character"), function(conn, x, ...) {
-  dbi_ensure_no_backtick(x)
+  if (length(x) == 0L) {
+    x
+  } else {
+    dbi_ensure_no_backtick(x)
 
-  y <- paste("`", x, "`", sep = "")
+    y <- paste("`", x, "`", sep = "")
 
-  SQL(y)
+    SQL(y)
+  }
 })
 
 setMethod("dbQuoteString", c("spark_connection", "character"), function(conn, x, ...) {


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>