### PR TITLE
cache Spark and Livy installations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,24 +20,28 @@ jobs:
             env:
               ARROW_ENABLED: 'false'
               SPARK_VERSION: '2.2.1'
+              LIVY_VERSION: 'NONE'
               JAVA_VERSION: 'oraclejdk8'
           - name: 'Spark 2.3.2 (R release, oraclejdk8)'
             r: 'release'
             env:
               ARROW_ENABLED: 'false'
               SPARK_VERSION: '2.3.2'
+              LIVY_VERSION: 'NONE'
               JAVA_VERSION: 'oraclejdk8'
           - name: 'Spark 2.4.4 (R release, oraclejdk8)'
             r: 'release'
             env:
               ARROW_ENABLED: 'false'
               SPARK_VERSION: '2.4.4'
+              LIVY_VERSION: 'NONE'
               JAVA_VERSION: 'oraclejdk8'
           - name: 'Spark 2.4.4 (R release, oraclejdk8, CODE_COVERAGE=true)'
             r: 'release'
             env:
               ARROW_ENABLED: 'false'
               SPARK_VERSION: '2.4.4'
+              LIVY_VERSION: 'NONE'
               JAVA_VERSION: 'oraclejdk8'
               CODE_COVERAGE: 'true'
           - name: 'Spark 3.0.0 (R release, oraclejdk8)'
@@ -45,44 +49,52 @@ jobs:
             env:
               ARROW_ENABLED: 'false'
               SPARK_VERSION: '3.0.0'
+              LIVY_VERSION: 'NONE'
               JAVA_VERSION: 'oraclejdk8'
           - name: 'Spark 3.0.0 (R release, openjdk11)'
             r: 'release'
             env:
               ARROW_ENABLED: 'false'
               SPARK_VERSION: '3.0.0'
+              LIVY_VERSION: 'NONE'
               JAVA_URL: 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz'
           - name: 'Livy 0.5.0 (R release, oraclejdk8, Spark 2.3.0)'
             r: 'release'
             env:
               ARROW_ENABLED: 'false'
-              LIVY_VERSION: '0.5.0'
               SPARK_VERSION: '2.3.0'
+              LIVY_VERSION: '0.5.0'
               JAVA_VERSION: 'oraclejdk8'
               SPARKLYR_LIVY_BRANCH: 'feature/sparklyr-1.5.0'
           - name: 'Livy 0.5.0 (R release, oraclejdk8, Spark 2.4.0)'
             r: 'release'
             env:
               ARROW_ENABLED: 'false'
-              LIVY_VERSION: '0.5.0'
               SPARK_VERSION: '2.4.0'
+              LIVY_VERSION: '0.5.0'
               JAVA_VERSION: 'oraclejdk8'
               SPARKLYR_LIVY_BRANCH: 'feature/sparklyr-1.5.0'
           - name: 'Arrow (release)'
             r: 'release'
             env:
               ARROW_ENABLED: 'true'
+              SPARK_VERSION: '3.0.0'
+              LIVY_VERSION: 'NONE'
               JAVA_VERSION: 'oraclejdk8'
           - name: 'Arrow (nightly)'
             r: 'release'
             env:
               ARROW_ENABLED: 'true'
               ARROW_VERSION: 'devel'
+              SPARK_VERSION: '3.0.0'
+              LIVY_VERSION: 'NONE'
               JAVA_VERSION: 'oraclejdk8'
           - name: 'Deps Devel (tidyverse, r-lib, forge)'
             r: 'release'
             env:
               ARROW_ENABLED: 'false'
+              SPARK_VERSION: '3.0.0'
+              LIVY_VERSION: 'NONE'
               R_DEVEL_PACKAGES: 'true'
     env:
       ${{ matrix.env }}
@@ -128,6 +140,13 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: sparklyr-${{ runner.os }}-r-${{ matrix.r }}-${{ env.ARROW_ENABLED }}-${{ hashFiles('DESCRIPTION') }}-${{ hashFiles('ci/install_r_dependencies.sh') }}
           restore-keys: sparklyr-${{ runner.os }}-r-${{ matrix.r }}
+      - name: Cache Spark & Livy installations
+        if: runner.os != 'Windows'
+        uses: actions/cache@master
+        with:
+          path: ~/spark
+          key: sparklyr-apache-spark-${{ runner.os }}-${{ env.SPARK_VERSION }}-${{ env.LIVY_VERSION }}
+          restore-keys: sparklyr-apache-spark-${{ runner.os }}-${{ env.SPARK_VERSION }}
       - name: Install system dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libcurl4-gnutls-dev procps socat

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -136,7 +136,7 @@ if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   test_filter <- NULL
 
   livy_version <- Sys.getenv("LIVY_VERSION")
-  if (nchar(livy_version) > 0) {
+  if (nchar(livy_version) > 0 && !identical(livy_version, "NONE")) {
     livy_tests <- c(
       "^dplyr$",
       "^dbi$",

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -32,7 +32,7 @@ spark_install_winutils <- function(version) {
 
 testthat_spark_connection <- function() {
   if (!exists(".testthat_latest_spark", envir = .GlobalEnv)) {
-    assign(".testthat_latest_spark", "2.3.0", envir = .GlobalEnv)
+    assign(".testthat_latest_spark", "3.0.0", envir = .GlobalEnv)
   }
 
   livy_branch <- Sys.getenv("SPARKLYR_LIVY_BRANCH")
@@ -43,7 +43,7 @@ testthat_spark_connection <- function() {
   livy_version <- Sys.getenv("LIVY_VERSION")
   test_databricks_connect <- Sys.getenv("TEST_DATABRICKS_CONNECT")
 
-  if (nchar(livy_version) > 0) {
+  if (nchar(livy_version) > 0 && !identical(livy_version, "NONE")) {
     testthat_livy_connection()
   } else if (test_databricks_connect == "true") {
     testthat_shell_connection(method = "databricks")
@@ -334,7 +334,8 @@ output_file <- function(filename) file.path("output", filename)
 
 skip_livy <- function() {
   livy_version <- Sys.getenv("LIVY_VERSION")
-  if (nchar(livy_version) > 0) skip("Test unsupported under Livy.")
+  if (nchar(livy_version) > 0 && !identical(livy_version, "NONE"))
+    skip("Test unsupported under Livy.")
 }
 
 check_params <- function(test_args, params) {

--- a/tests/testthat/test-sdf-collect.R
+++ b/tests/testthat/test-sdf-collect.R
@@ -36,7 +36,7 @@ test_that("sdf_collect() works with nested lists", {
   res <- sdf_collect(sdf)
 
   expect_equivalent(df$a, res$a)
-  expect_equivalent(df$b, sapply(res$b, function(e) do.call(c, e)))
+  expect_equivalent(df$b, sapply(res$b, function(x) do.call(c, as.list(x))))
 })
 
 test_that("sdf_collect() works with nested named lists", {


### PR DESCRIPTION
making this change because otherwise frequent repeated downloading of Spark and Livy tar files can sometimes be an issue for archive.apache.org

Signed-off-by: Yitao Li <yitao@rstudio.com>