### PR TITLE
doSpark should use default parallelism from SparkContext as number of partitions/workers

### DIFF
--- a/man/registerDoSpark.Rd
+++ b/man/registerDoSpark.Rd
@@ -2,12 +2,17 @@
 % Please edit documentation in R/do_spark.R
 \name{registerDoSpark}
 \alias{registerDoSpark}
-\title{Register a Prallel Backend}
+\title{Register a Parallel Backend}
 \usage{
-registerDoSpark(spark_conn, ...)
+registerDoSpark(spark_conn, parallelism = NULL, ...)
 }
 \arguments{
-\item{spark_conn}{spark connection to use}
+\item{spark_conn}{Spark connection to use}
+
+\item{parallelism}{Level of parallelism to use for task execution
+(if unspecified, then it will take the value of
+ `SparkContext.defaultParallelism()` which by default is the number
+ of cores available to the `sparklyr` application)}
 
 \item{...}{additional options for sparklyr parallel backend
 (currently only the only valid option is nocompile = {T, F})}

--- a/man/registerDoSpark.Rd
+++ b/man/registerDoSpark.Rd
@@ -4,13 +4,10 @@
 \alias{registerDoSpark}
 \title{Register a Prallel Backend}
 \usage{
-registerDoSpark(spark_conn, min_executors = 0L, ...)
+registerDoSpark(spark_conn, ...)
 }
 \arguments{
 \item{spark_conn}{spark connection to use}
-
-\item{min_executors}{Minimum number of Spark executors that is expected to be
-available}
 
 \item{...}{additional options for sparklyr parallel backend
 (currently only the only valid option is nocompile = {T, F})}


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>