### PR TITLE
fix how spark config shell args processes multi-valued parameters such as `--conf`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 - Support for `sparklyr.livy.sources` is removed completely as it is no longer
   needed as a workaround when Spark version is specified.
 
+- A bug in how multiple `--conf` values were handled in some scenarios within
+  the spark-submit shell args which was introduced in sparklyr 1.4 has been
+  fixed now.
+
 ### Data
 
 - `stream_lag()` is implemented to provide the equivalent functionality of

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -94,7 +94,8 @@ spark_config_shell_args <- function(config, master) {
   unlist(lapply(seq_along(shell_args), function(idx) {
     name <- names(shell_args)[[idx]]
     value <- shell_args[[idx]]
-    list(paste0("--", name), value)
+
+    lapply(as.list(value), function(x) list(paste0("--", name), x))
   }))
 }
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -60,15 +60,28 @@ test_that("spark_config() can load from options", {
 })
 
 test_that("spark_config_shell_args() works as expected", {
-  config <- list(
-    sparklyr.shell.conf = "key1=value1",
-    sparklyr.shell.conf = "key2=value2",
-    sparklyr.shell.key3 = "value3",
-    sparklyr.shell.packages = c("pkg1", "pkg2", "pkg3")
+  configs <- list(
+    list(
+      sparklyr.shell.conf = "key1=value1",
+      sparklyr.shell.conf = "key2=value2",
+      sparklyr.shell.key3 = "value3",
+      sparklyr.shell.packages = c("pkg1", "pkg2", "pkg3")
+    ),
+    list(
+      sparklyr.shell.conf = c("key1=value1", "key2=value2"),
+      sparklyr.shell.key3 = "value3",
+      sparklyr.shell.packages = c("pkg1", "pkg2", "pkg3")
+    )
   )
-
-  expect_equal(
-    spark_config_shell_args(config = config, master = "local"),
-    c("--conf", "key1=value1", "--conf", "key2=value2", "--key3", "value3", "--packages", "pkg1,pkg2,pkg3")
-  )
+  for (config in configs) {
+    expect_equal(
+      spark_config_shell_args(config = config, master = "local"),
+      c(
+        "--conf", "key1=value1",
+        "--conf", "key2=value2",
+        "--key3", "value3",
+        "--packages", "pkg1,pkg2,pkg3"
+      )
+    )
+  }
 })


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>