### PR TITLE
run spark_apply test cases separately from the rest of Livy test cases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
 
 name: CI
 
+env:
+  SPARKLYR_LIVY_BRANCH: 'feature/sparklyr-1.5.0'
+
 jobs:
   CI:
     runs-on: ubuntu-latest
@@ -65,7 +68,14 @@ jobs:
               SPARK_VERSION: '2.3.0'
               LIVY_VERSION: '0.5.0'
               JAVA_VERSION: 'oraclejdk8'
-              SPARKLYR_LIVY_BRANCH: 'feature/sparklyr-1.5.0'
+          - name: 'Livy 0.5.0 spark_apply (R release, oraclejdk8, Spark 2.3.0)'
+            r: 'release'
+            env:
+              ARROW_ENABLED: 'false'
+              SPARK_VERSION: '2.3.0'
+              LIVY_VERSION: '0.5.0'
+              JAVA_VERSION: 'oraclejdk8'
+              RUN_SPARK_APPLY_TESTS: 'true'
           - name: 'Livy 0.5.0 (R release, oraclejdk8, Spark 2.4.0)'
             r: 'release'
             env:
@@ -73,7 +83,14 @@ jobs:
               SPARK_VERSION: '2.4.0'
               LIVY_VERSION: '0.5.0'
               JAVA_VERSION: 'oraclejdk8'
-              SPARKLYR_LIVY_BRANCH: 'feature/sparklyr-1.5.0'
+          - name: 'Livy 0.5.0 spark_apply (R release, oraclejdk8, Spark 2.4.0)'
+            r: 'release'
+            env:
+              ARROW_ENABLED: 'false'
+              SPARK_VERSION: '2.4.0'
+              LIVY_VERSION: '0.5.0'
+              JAVA_VERSION: 'oraclejdk8'
+              RUN_SPARK_APPLY_TESTS: 'true'
           - name: 'Arrow (release)'
             r: 'release'
             env:

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -137,14 +137,19 @@ if (identical(Sys.getenv("NOT_CRAN"), "true")) {
 
   livy_version <- Sys.getenv("LIVY_VERSION")
   if (nchar(livy_version) > 0 && !identical(livy_version, "NONE")) {
-    livy_tests <- c(
-      "^dplyr$",
-      "^dbi$",
-      "^copy-to$",
-      "^spark-apply$",
-      "^ml-clustering-kmeans$",
-      "^livy-config$",
-      "^livy-proxy$"
+    livy_tests <- (
+      if (identical(Sys.getenv("RUN_SPARK_APPLY_TESTS"), "true")) {
+        "^spark-apply$"
+      } else {
+        c(
+          "^dplyr$",
+          "^dbi$",
+          "^spark-apply$",
+          "^ml-clustering-kmeans$",
+          "^livy-config$",
+          "^livy-proxy$"
+        )
+      }
     )
 
     test_filter <- paste(livy_tests, collapse = "|")


### PR DESCRIPTION
Seems like running all of them within a single CI flow will always cause `SparkOutOfMemoryError`

Signed-off-by: Yitao Li <yitao@rstudio.com>