### PR TITLE
update Spark version requirement for the cumulative product UDAF

### DIFF
--- a/tests/testthat/test-dplyr-stats.R
+++ b/tests/testthat/test-dplyr-stats.R
@@ -61,6 +61,7 @@ test_that("cor, cov, sd and var works as expected over groups", {
 })
 
 test_that("cumprod works as expected", {
+  test_requires_version("2.0.0")
   test_requires("dplyr")
 
   for (stats in list(


### PR DESCRIPTION
This UDAF should work in Spark 1.6 (or even Spark 1.5) according to the Spark API documentation. The only reason it didn't was because of some implementation bug in Spark 1.6.

Signed-off-by: Yitao Li <yitao@rstudio.com>