### PR TITLE
delete `lifecycle` from Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: sparklyr
 Title: R Interface to Apache Spark
 Version: 1.5.2
-Authors@R: 
+Authors@R:
     c(person(given = "Javier",
              family = "Luraschi",
              role = "aut",
@@ -84,7 +84,6 @@ Imports:
     glue,
     httr (>= 1.2.1),
     jsonlite (>= 1.4),
-    lifecycle,
     methods,
     openssl (>= 0.8),
     purrr,


### PR DESCRIPTION
Looks like it's actually not used anywhere at the moment (!!)

Signed-off-by: Yitao Li <yitao@rstudio.com>