### PR TITLE
support "handle invalid" configuration for ft_vector_indexer in Spark 2.3 or above

### DIFF
--- a/R/ml_feature_vector_indexer.R
+++ b/R/ml_feature_vector_indexer.R
@@ -5,10 +5,12 @@
 #' @template roxlate-ml-feature-input-output-col
 #' @template roxlate-ml-feature-transformer
 #' @template roxlate-ml-feature-estimator-transformer
+#' @template roxlate-ml-feature-handle-invalid
 #' @param max_categories Threshold for the number of values a categorical feature can take. If a feature is found to have > \code{max_categories} values, then it is declared continuous. Must be greater than or equal to 2. Defaults to 20.
 #'
 #' @export
 ft_vector_indexer <- function(x, input_col = NULL, output_col = NULL,
+                              handle_invalid = "error",
                               max_categories = 20,
                               uid = random_string("vector_indexer_"), ...) {
   check_dots_used()
@@ -19,11 +21,13 @@ ml_vector_indexer <- ft_vector_indexer
 
 #' @export
 ft_vector_indexer.spark_connection <- function(x, input_col = NULL, output_col = NULL,
+                                               handle_invalid = "error",
                                                max_categories = 20,
                                                uid = random_string("vector_indexer_"), ...) {
   .args <- list(
     input_col = input_col,
     output_col = output_col,
+    handle_invalid = handle_invalid,
     max_categories = max_categories,
     uid = uid
   ) %>%
@@ -34,6 +38,7 @@ ft_vector_indexer.spark_connection <- function(x, input_col = NULL, output_col =
     x, "org.apache.spark.ml.feature.VectorIndexer",
     input_col = .args[["input_col"]], output_col = .args[["output_col"]], uid = .args[["uid"]]
   ) %>%
+    jobj_set_param("setHandleInvalid", .args[["handle_invalid"]], "2.3.0", "error") %>%
     invoke("setMaxCategories", .args[["max_categories"]]) %>%
     new_ml_vector_indexer()
 

--- a/man/ft_vector_indexer.Rd
+++ b/man/ft_vector_indexer.Rd
@@ -8,6 +8,7 @@ ft_vector_indexer(
   x,
   input_col = NULL,
   output_col = NULL,
+  handle_invalid = "error",
   max_categories = 20,
   uid = random_string("vector_indexer_"),
   ...
@@ -19,6 +20,10 @@ ft_vector_indexer(
 \item{input_col}{The name of the input column.}
 
 \item{output_col}{The name of the output column.}
+
+\item{handle_invalid}{(Spark 2.1.0+) Param for how to handle invalid entries. Options are
+'skip' (filter out rows with invalid values), 'error' (throw an error), or
+'keep' (keep invalid values in a special additional bucket). Default: "error"}
 
 \item{max_categories}{Threshold for the number of values a categorical feature can take. If a feature is found to have > \code{max_categories} values, then it is declared continuous. Must be greater than or equal to 2. Defaults to 20.}
 


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>