### PR TITLE
Revert "implement support for `all()` and `any()` for Spark dataframes"

### DIFF
--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -142,22 +142,6 @@ build_sql_if_compare <- function(..., con, compare) {
   build_sql_if_parts(conditions, args)
 }
 
-#' @importFrom dbplyr sql
-build_sql_infix_op <- function(..., con, op) {
-  preds <- list(...)
-  build_sql_args <- list()
-  for (i in seq(1, length(preds) - 1)) {
-    build_sql_args <- append(
-      build_sql_args,
-      list(preds[[i]], sprintf(" %s ", op))
-    )
-  }
-  build_sql_args <- append(build_sql_args, list(preds[[length(preds)]]))
-  build_sql_args <- append(build_sql_args, list(con = con))
-
-  do.call(dbplyr::build_sql, build_sql_args)
-}
-
 #' @rawNamespace
 #' if (utils::packageVersion("dbplyr") < "2") {
 #'   importFrom(dplyr, sql_translate_env)
@@ -232,12 +216,6 @@ spark_sql_translation <- function(con) {
       xor = function(x, y) dbplyr::build_sql(x, " ^ ", y),
       or = function(x, y) dbplyr::build_sql(x, " OR ", y),
       and = function(x, y) dbplyr::build_sql(x, " AND ", y),
-      all = function(...) {
-        build_sql_infix_op(..., con = con, op = "AND")
-      },
-      any = function(...) {
-        build_sql_infix_op(..., con = con, op = "OR")
-      },
       pmin = function(...) build_sql_if_compare(..., con = con, compare = "<="),
       pmax = function(...) build_sql_if_compare(..., con = con, compare = ">="),
       `%like%` = function(x, y) dbplyr::build_sql(x, " LIKE ", y),

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -148,28 +148,6 @@ test_that("'head' uses 'limit' clause", {
   )
 })
 
-test_that("'all' works as expected", {
-  test_requires("dplyr")
-
-  expect_equal(
-    sdf_len(sc, 20) %>%
-      filter(all(id > 5, id < 19, id %% 3 == 1)) %>%
-      pull(id),
-    c(7L, 10L, 13L, 16L)
-  )
-})
-
-test_that("'any' works as expected", {
-  test_requires("dplyr")
-
-  expect_equal(
-    sdf_len(sc, 20) %>%
-      filter(any(id < 5, id > 16, id %% 7 == 1)) %>%
-      pull(id),
-    c(seq(4), 8L, 15L, seq(17, 20))
-  )
-})
-
 test_that("'sdf_broadcast' forces broadcast hash join", {
   query_plan <- df1_tbl %>%
     sdf_broadcast() %>%


### PR DESCRIPTION
Reverts sparklyr/sparklyr#2925

(implementing the exact equivalent of `all()` or `any()` semantic followed by `dplyr::group_by()` in Spark SQL appears to be not possible at the moment)