### PR TITLE
correct arrow_enabled to match usage

### DIFF
--- a/R/arrow_data.R
+++ b/R/arrow_data.R
@@ -3,7 +3,7 @@ NULL
 
 arrow_enabled <- function(sc, object) {
   has_arrow <- "package:arrow" %in% search()
-  spark_config_value(sc, "sparklyr.arrow", has_arrow) &&
+  spark_config_value(sc$config, "sparklyr.arrow", has_arrow) &&
     arrow_enabled_object(object)
 }
 


### PR DESCRIPTION
Callers of arrow_enabled pass a spark connection, but the implementaion
of that function tries to read a config value from its first argument.
To match with its usage, this commit changes arrow_enabled to read a
config value off of sc$config.