### PR TITLE
avoid evaluating expressions twice in `transmute.tbl_spark()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,9 @@
   weighted quantiles using a modified version of the Greenwald-Khanna algorithm
   that takes relative weight of each data point into consideration.
 
+- Fixed a problem of some expressions being evaluated twice in
+  `transmute.tbl_spark()` (see tidyverse/dbplyr#605)
+
 ### Serialization
 
 - `spark_write_rds()` was implemented to support exporting all partitions of a
@@ -52,13 +55,17 @@
 - Spark map type will be collected as list instead of environment in R in order
   to support empty string as key
 
-### Connections
-
-- Created convenience functions for working with Spark runtime configurations
+- Fixed a configuration-related bug in `sparklyr:::arrow_enabled()`
 
 - Implemented spark-apply-specific configuration option for Arrow max records
   per batch, which can be different from the
   `spark.sql.execution.arrow.maxRecordsPerBatch` value from Spark session config
+
+### Connections
+
+- Created convenience functions for working with Spark runtime configurations
+
+- Fixed buggy exit code from the `spark-submit` process launched by sparklyr
 
 ### Spark ML
 

--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -19,9 +19,10 @@ fix_na_real_values <- function(dots) {
 #' @importFrom dplyr transmute
 transmute.tbl_spark <- function(.data, ...) {
   dots <- rlang::enquos(..., .named = TRUE) %>%
-    fix_na_real_values()
+    fix_na_real_values() %>%
+    partial_eval_dots(sim_data = simulate_vars(.data))
 
-  do.call(NextMethod, dots)
+  nest_vars(.data, dots, character())
 }
 
 #' @export

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -3,6 +3,7 @@ context("dplyr")
 sc <- testthat_spark_connection()
 
 iris_tbl <- testthat_tbl("iris")
+mtcars_tbl <- testthat_tbl("mtcars")
 test_requires("dplyr")
 
 df1 <- tibble(a = 1:3, b = letters[1:3])
@@ -67,7 +68,7 @@ test_that("'summarize' works with where(...) predicate", {
   )
 })
 
-test_that("the implementation of 'mutate' functions as expected", {
+test_that("'mutate' works as expected", {
   test_requires("dplyr")
 
   expect_equal(
@@ -98,6 +99,20 @@ test_that("'across()' works with formula syntax", {
   expect_equivalent(
     dplyr_across_test_cases_tbl %>% mutate(across(where(is.numeric), ~ sin(.x ^ 3 + .x))) %>% collect(),
     dplyr_across_test_cases_df %>% mutate(across(where(is.numeric), ~ sin(.x ^ 3 + .x)))
+  )
+})
+
+test_that("'mutate' and 'transmute' work with NSE", {
+  test_requires("dplyr")
+  col <- "mpg"
+
+  expect_equivalent(
+    mtcars_tbl %>% mutate(!!col := !!rlang::sym(col) * 2) %>% collect(),
+    mtcars %>% mutate(!!col := !!rlang::sym(col) * 2)
+  )
+  expect_equivalent(
+    mtcars_tbl %>% transmute(!!col := !!rlang::sym(col) * 2) %>% collect(),
+    mtcars %>% transmute(!!col := !!rlang::sym(col) * 2)
   )
 })
 


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>