### PR TITLE
make dbExistsTable perform case-insensitive comparisons on table names

### DIFF
--- a/R/dbi_spark_table.R
+++ b/R/dbi_spark_table.R
@@ -47,7 +47,7 @@ setMethod("dbListTables", "spark_connection", function(conn) {
 
 
 setMethod("dbExistsTable", c("spark_connection", "character"), function(conn, name) {
-  name %in% dbListTables(conn)
+  tolower(name) %in% tolower(dbListTables(conn))
 })
 
 

--- a/tests/testthat/test-dbi.R
+++ b/tests/testthat/test-dbi.R
@@ -37,6 +37,14 @@ test_that("dbGetQuery works with parameterized queries", {
   expect_equal(nrow(virginica), 50)
 })
 
+test_that("dbExistsTable performs case-insensitive comparisons on table names", {
+  sdf <- copy_to(sc, data.frame(a = 1, b = 2), name = "testTempView")
+
+  expect_true(dbExistsTable(sc, "testTempView"))
+  expect_true(dbExistsTable(sc, "TESTTEMPVIEW"))
+  expect_true(dbExistsTable(sc, "testtempview"))
+})
+
 teardown({
   dbRemoveTable(sc, persisted_table_name)
   dbRemoveTable(sc, temp_table_name)


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>