### PR TITLE
prepare for sparklyr 1.6.1 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: sparklyr
 Title: R Interface to Apache Spark
-Version: 1.6.0
+Version: 1.6.1
 Authors@R:
     c(person(given = "Javier",
              family = "Luraschi",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,27 @@
+# Sparklyr 1.6.1
+
+### Data
+
+- `sdf_distinct()` is implemented to be an R interface for `distinct()` operation
+  on Spark dataframes (NOTE: this is different from the `dplyr::distinct()`
+  operation, as `dplyr::distinct()` operation on a Spark dataframe now supports
+  `.keep_all = TRUE` and has more complex ordering requirements)
+
+- Fixed a problem of some expressions being evaluated twice in
+  `transmute.tbl_spark()` (see tidyverse/dbplyr#605)
+
+- `dbExistsTable()` now performs case insensitive comparison with table names to
+  be consistent with how table names are handled by Spark catalog API
+
+- Fixed a bug with `sql_query_save()` not overwriting a temp table with identical
+  name
+
+- Revised `sparklyr:::process_tbl_name()` to correctly handle inputs that are not
+  table names
+
+- Bug fix: `db_save_query.spark_connection()` should also cache the view it
+  created in Spark
+
 # Sparklyr 1.6.0
 
 ### Data
@@ -38,9 +62,6 @@
   `dplyr::distinct()` implementation to a basic one that only adds ‘DISTINCT’
   clause to the current Spark SQL query, does not support the `.keep_all = TRUE`
   option, and (3) does not have any ordering guarantee for the output.
-
-- Bug fix: `db_save_query.spark_connection()` should also cache the view that
-  was created in Spark
 
 ### Serialization
 

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -596,7 +596,7 @@ livy_connection_jars <- function(config, version, scala_version) {
       target_jar <- stringr::str_sort(target_jar)[[1]]
     }
 
-    livy_branch <- spark_config_value(config, "sparklyr.livy.branch", "feature/sparklyr-1.6.0")
+    livy_branch <- spark_config_value(config, "sparklyr.livy.branch", "feature/sparklyr-1.6.1")
 
     livy_jars <- paste0(
       "https://github.com/sparklyr/sparklyr/blob/",


### PR DESCRIPTION
- There were a number of bug fixes as follow-ups from the previous 1.6.0 release.
- Also `sdf_distinct()` didn't make the 1.6.0 release window but it should be part of sparklyr 1.6.1

Signed-off-by: Yitao Li <yitao@rstudio.com>