### PR TITLE
bug fix: db_save_query.spark_connection should also cache the view

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,9 @@
   clause to the current Spark SQL query, does not support the `.keep_all = TRUE`
   option, and (3) does not have any ordering guarantee for the output.
 
+- Bug fix: `db_save_query.spark_connection()` should also cache the view that
+  was created in Spark
+
 ### Serialization
 
 - `spark_write_rds()` was implemented to support exporting all partitions of a

--- a/R/dplyr_spark.R
+++ b/R/dplyr_spark.R
@@ -1,5 +1,6 @@
 #' @include spark_dataframe.R
 #' @include spark_sql.R
+#' @include tables_spark.R
 NULL
 
 #' @export
@@ -187,6 +188,7 @@ print.src_spark <- function(x, ...) {
 db_save_query.spark_connection <- function(con, sql, name, temporary = TRUE, ...) {
   create_temp_view_sql <- spark_sql_query_save(con, sql, name, temporary, ...)
   DBI::dbGetQuery(con, create_temp_view_sql)
+  tbl_cache_sql(con, name = name, force = TRUE)
 
   # dbplyr expects db_save_query to retrieve the table name
   name


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>