### PR TITLE
ensure all download.file() calls in `sparklyr` has a minimum timeout of 300 seconds

### DIFF
--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -187,7 +187,7 @@ spark_install <- function(version = NULL,
       message(msg)
     }
 
-    status <- suppressWarnings(download.file(
+    status <- suppressWarnings(download_file(
       installInfo$packageRemotePath,
       destfile = installInfo$packageLocalPath,
       quiet = !verbose

--- a/R/livy_install.R
+++ b/R/livy_install.R
@@ -117,7 +117,7 @@ livy_install <- function(version = "0.6.0",
     message("* Installing to:\n- ", shQuote(aliased_path(livy_path)))
   }
 
-  download.file(url, destfile = destfile)
+  download_file(url, destfile = destfile)
   if (!file.exists(destfile)) {
     stop("livy download failed")
   }

--- a/R/spark_compile.R
+++ b/R/spark_compile.R
@@ -370,7 +370,7 @@ download_scalac <- function(dest_path = NULL) {
       dir.create(dirname(dest_file), recursive = TRUE)
     }
 
-    download.file(download_url, destfile = dest_file)
+    download_file(download_url, destfile = dest_file)
 
     if (ext == "zip") {
       unzip(dest_file, exdir = dest_path)

--- a/R/utils.R
+++ b/R/utils.R
@@ -397,3 +397,19 @@ simulate_vars <- function(sdf) {
     ) %>%
     tibble::as_tibble()
 }
+
+# wrapper for download.file()
+download_file <- function(...) {
+  min_timeout_s <- 300
+
+  # Temporarily set download.file() timeout to 300 seconds if it was
+  # previously less than that, and restore the previous timeout setting
+  # on exit.
+  prev_timeout_s <- getOption("timeout")
+  if (prev_timeout_s < min_timeout_s) {
+    on.exit(options(timeout = prev_timeout_s))
+    options(timeout = min_timeout_s)
+  }
+
+  download.file(...)
+}


### PR DESCRIPTION
because the default value of 60 seconds may not be enough for non-small files (i.e., 200 MB or more)

Signed-off-by: Yitao Li <yitao@rstudio.com>