### PR TITLE
revise handling of Spark versions

### DIFF
--- a/R/spark_version.R
+++ b/R/spark_version.R
@@ -140,6 +140,17 @@ spark_version_latest <- function(version = NULL) {
   if (is.null(version)) {
     versions[length(versions)]
   } else {
-    max(versions[grepl(version, versions, fixed = TRUE)])
+    # suppress 'no non-missing arguments, returning NA' warnings (handled below)
+    version <- suppressWarnings(
+      max(versions[grepl(version, versions, fixed = TRUE)])
+    )
+
+    if (is.na(version)) {
+      # If the user-supplied version does not match any of the known version numbers,
+      # then return the highest Spark version we know so far.
+      versions[length(versions)]
+    } else {
+      version
+    }
   }
 }

--- a/inst/extdata/versions.json
+++ b/inst/extdata/versions.json
@@ -430,5 +430,29 @@
     "hadoop": "3.2",
     "base": "https://archive.apache.org/dist/spark/spark-3.0.1/",
     "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "3.0.2",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-3.0.2/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "3.0.2",
+    "hadoop": "3.2",
+    "base": "https://archive.apache.org/dist/spark/spark-3.0.2/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "3.1.1",
+    "hadoop": "2.7",
+    "base": "https://archive.apache.org/dist/spark/spark-3.1.1/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
+  },
+  {
+    "spark": "3.1.1",
+    "hadoop": "3.2",
+    "base": "https://archive.apache.org/dist/spark/spark-3.1.1/",
+    "pattern": "spark-%s-bin-hadoop%s.tgz"
   }
 ]


### PR DESCRIPTION
- If user-supplied Spark version does not match any of the known Spark versions, then simply return the highest-known version number as the "presumed version" for maximal compatibility
- Updating the list of known Spark versions

Signed-off-by: Yitao Li <yitao@rstudio.com>