### PR TITLE
emit correct error message for the non-existent OneHotEncoderEstimator class in Spark 3.0 and above

### DIFF
--- a/R/ml_feature_one_hot_encoder_estimator.R
+++ b/R/ml_feature_one_hot_encoder_estimator.R
@@ -30,7 +30,7 @@ ml_one_hot_encoder_estimator <- ft_one_hot_encoder_estimator
 ft_one_hot_encoder_estimator.spark_connection <- function(x, input_cols = NULL, output_cols = NULL,
                                                           handle_invalid = "error", drop_last = TRUE,
                                                           uid = random_string("one_hot_encoder_estimator_"), ...) {
-  spark_require_version(x, "2.3.0", "3.0.0")
+  spark_require_version(x, required = "2.3.0", required_max = "3.0.0")
 
   .args <- list(
     input_cols = input_cols,


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>