### PR TITLE
warn user if invalid or non-existent config file is provided to spark_config()

### DIFF
--- a/R/config_spark.R
+++ b/R/config_spark.R
@@ -31,7 +31,20 @@ spark_config <- function(file = "config.yml", use_default = TRUE) {
   userEnvConfig <- tryCatch(config::get(file = Sys.getenv("SPARKLYR_CONFIG_FILE")), error = function(e) NULL)
   baseEnvConfig <- merge_lists(baseConfig, userEnvConfig)
 
-  userConfig <- tryCatch(config::get(file = file), error = function(e) NULL)
+  isFileProvided <- !missing(file)
+  userConfig <- tryCatch(
+    config::get(file = file),
+    error = function(e) {
+      if (isFileProvided) {
+        warnMessage <- sprintf(
+          "Error reading config file: %s in spark_config(): %s: %s. File will be ignored.",
+          file, deparse(e[["call"]]), e[["message"]]
+        )
+        warning(warnMessage, call. = FALSE)
+      }
+      NULL
+    }
+  )
 
   mergedConfig <- merge_lists(baseEnvConfig, userConfig)
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -85,3 +85,31 @@ test_that("spark_config_shell_args() works as expected", {
     )
   }
 })
+
+test_that("spark_config() warns if invalid config file that exists is passed", {
+  configFilePath <- tempfile(pattern = "config_", fileext = ".yml")
+  invalidConfigContent <- c(
+    "default:",
+    "  spark.num.executors: 1",
+    "  spark.executor.memory: 2g",
+    "  spark.executor.memory: 5g"
+  )
+  writeLines(text = invalidConfigContent, con = configFilePath)
+  expect_warning(
+    spark_config(file = configFilePath),
+    "Error reading config file:"
+  )
+})
+
+test_that("spark_config() is silent if no config file is passed", {
+  expect_silent(
+    spark_config()
+  )
+})
+
+test_that("spark_config warns() if non-existent file is passed", {
+  expect_warning(
+    spark_config(file = tempfile(paste(sample(letters, 5L), collapse = ""))),
+    "Error reading config file:"
+  )
+})


### PR DESCRIPTION
Currently if the user provides an invalid or non-existent config `file` argument to `spark_config()`, that file is silently ignored. This PR proposes to warn the user in case `file` is explicitly provided but will be ignored. The added unit test cases show 2 common scenarios in which the warning can be useful.