### PR TITLE
Unblock the use of Livy client config starting with livy.rsc

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -222,7 +222,7 @@ livy_create_session <- function(master, config) {
     conf = livy_config_get(master, config)
   )
 
-  session_params <- connection_config(list(master = master, config = config), "livy.", "livy.session.")
+  session_params <- connection_config(list(master = master, config = config), "livy.", "livy.rsc.", "livy.session.")
   if (length(session_params) > 0) data <- append(data, session_params)
 
   req <- POST(paste(master, "sessions", sep = "/"),


### PR DESCRIPTION
Unblock the use of the Livy client config starting with "livy.rsc". See issue #3140