### PR TITLE
Implement sparklyr changes for Databricks notebook-scoped libraries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,12 @@
 - Fixed a bug that previously caused invoke params containing `NaN`s to be
   serialized incorrectly.
 
+### Connections
+
+- Added support for notebook-scoped libraries on Databricks connections.
+  Previously, libPaths were not shared between driver and worker in sparklyr.
+  Now, they are.
+
 ### Spark ML
 
 - `ml_compute_silhouette_measure()` was implemented to evaluate the

--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -40,6 +40,11 @@ databricks_connection <- function(config, extensions) {
     }
   )
 
+  # Hand in driver's libPaths to worker if user hasn't already set libpaths for notebook-scoped libraries
+  if (is.null(config$spark.r.libpaths)) {
+    config$spark.r.libpaths <- toString(.libPaths())
+  }
+
   new_databricks_connection(
     gateway_connection(
       paste("sparklyr://localhost:", gatewayPort, "/", gatewayPort, sep = ""),

--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -41,9 +41,7 @@ databricks_connection <- function(config, extensions) {
   )
 
   # Hand in driver's libPaths to worker if user hasn't already set libpaths for notebook-scoped libraries
-  if (is.null(config$spark.r.libpaths)) {
-    config$spark.r.libpaths <- toString(.libPaths())
-  }
+    config$spark.r.libpaths <- config$spark.r.libpaths %||% paste(.libPaths(), collapse = ",")
 
   new_databricks_connection(
     gateway_connection(

--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -41,7 +41,7 @@ databricks_connection <- function(config, extensions) {
   )
 
   # Hand in driver's libPaths to worker if user hasn't already set libpaths for notebook-scoped libraries
-    config$spark.r.libpaths <- config$spark.r.libpaths %||% paste(.libPaths(), collapse = ",")
+  config$spark.r.libpaths <- config$spark.r.libpaths %||% paste(.libPaths(), collapse = ",")
 
   new_databricks_connection(
     gateway_connection(

--- a/tests/testthat/test-databricks-connect.R
+++ b/tests/testthat/test-databricks-connect.R
@@ -18,3 +18,9 @@ test_that("spark local property is set", {
   client_type <- spark_context(sc) %>% invoke("getLocalProperty", "spark.databricks.service.client.type")
   expect_equal(client_type, "sparklyr")
 })
+
+test_that("spark libpaths config is set", {
+  sc <- testthat_spark_connection()
+
+  expect_false(is.null(sc$config$spark.r.libpaths))
+})


### PR DESCRIPTION
I am creating this PR to give sparklyr users a better experience on Databricks with respect to notebook-scoped libraries.