### PR TITLE
Java Version Validation

### DIFF
--- a/R/java.R
+++ b/R/java.R
@@ -94,7 +94,9 @@ validate_java_version_line <- function(master, version) {
     strsplit(versionLine, "\"")[[1]][[2]]
   } else {
     splat <- strsplit(versionLine, "\\s+", perl = TRUE)[[1]]
-    splat[grepl("9|[0-9]+\\.[0-9]+\\.[0-9]+", splat)]
+    #Getting rid of dates when present before parsing version from 'java -version'
+    splat <- splat[!grepl("[0-9]{4}-[0-9]{2}-[0-9]{2}", splat)]
+    splat[grepl("[0-9]{1,2}(\\.[0-9]+\\.[0-9]+)?", splat)]
   }
 
   if (length(splatVersion) != 1) {
@@ -121,8 +123,8 @@ validate_java_version_line <- function(master, version) {
   }
 
   if (compareVersion(parsedVersion, "1.9") >= 0 &&
-    compareVersion(parsedVersion, "11") == -1 &&
-    spark_master_is_local(master) && !getOption("sparklyr.java9", FALSE)) {
+      compareVersion(parsedVersion, "11") == -1 &&
+      spark_master_is_local(master) && !getOption("sparklyr.java9", FALSE)) {
     stop(
       "Java 9 is currently unsupported in Spark distributions unless you manually install Hadoop 2.8 ",
       "and manually configure Spark. Please consider uninstalling Java 9 and reinstalling Java 8. ",

--- a/R/java.R
+++ b/R/java.R
@@ -123,8 +123,8 @@ validate_java_version_line <- function(master, version) {
   }
 
   if (compareVersion(parsedVersion, "1.9") >= 0 &&
-      compareVersion(parsedVersion, "11") == -1 &&
-      spark_master_is_local(master) && !getOption("sparklyr.java9", FALSE)) {
+    compareVersion(parsedVersion, "11") == -1 &&
+    spark_master_is_local(master) && !getOption("sparklyr.java9", FALSE)) {
     stop(
       "Java 9 is currently unsupported in Spark distributions unless you manually install Hadoop 2.8 ",
       "and manually configure Spark. Please consider uninstalling Java 9 and reinstalling Java 8. ",

--- a/tests/testthat/test-java.R
+++ b/tests/testthat/test-java.R
@@ -51,3 +51,34 @@ test_that("'validate_java_version_line' works with java 9 in non-local mode", {
 
   succeed()
 })
+
+# Since adoption of JEP 223, some Java versions are released only with Major
+# version and no Minor.Security information. In such cases version is shown as
+# X instead of X.0.0
+# Also newer versions include a date as part of the version string. Must be able
+# to differentiate numbers from dates from numbers from release.
+test_that("'validate_java_version_line' works on version without minor.security and date exists", {
+  validate_java_version_line(
+    "local",
+    c(
+      "java version \"11\" 2018-09-25",
+      "Java(TM) SE Runtime Environment (build 00+00-0000)",
+      "Java HotSpot(TM) 64-Bit Server VM (build 00+00-0000, mixed mode, sharing)"
+    )
+  )
+
+  succeed()
+})
+
+test_that("'validate_java_version_line' works when date is present and version has x.y.z format", {
+  validate_java_version_line(
+    "local",
+    c(
+      "java version \"15.0.2\" 2021-01-19",
+      "Java(TM) SE Runtime Environment (build 15.0.2+7-27)",
+      "Java HotSpot(TM) 64-Bit Server VM (build 15.0.2+7-27, mixed mode, sharing)"
+    )
+  )
+
+  succeed()
+})


### PR DESCRIPTION
Since adoption of JEP 223, some Java versions are released only with Major version and no Minor.Security information. In such cases version is shown as X instead of X.0.0, and current regex will not match them.
Also, newer Java versions include a date as part of the version string. We must be able to differentiate numbers from dates from numbers from release, otherwise in some rare cases both version and date will be matched by the current regex resulting in failed validation due to output length.
View issue #1383 for further details.

The proposed change splits the string parsing into 2 steps.
- Trying to match date format (dddd-dd-dd) in the string and filter that out if any match exists (d = digits)
- Match within the remaining results a version in the format of 1 or 2 staring digits followed by zero or one occurrences of '.digit(s).digit(s)' pattern.