### PR TITLE
use GITHUB_TOKEN to authenticate `remotes::install_github()` web requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,12 @@ on:
 
 name: CI
 
+env:
+  # Ensure the temporary auth token for this workflow, instead of the
+  # bundled GitHub PAT from the `remotes` package is used for
+  # `remotes::install_github()`
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   CI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>