### PR TITLE
ensure "sparklyr.cores.local" takes precedence over "sparklyr.connect.cores.local"

### DIFF
--- a/R/config_spark.R
+++ b/R/config_spark.R
@@ -53,7 +53,7 @@ spark_config <- function(file = "config.yml", use_default = TRUE) {
     mergedConfig$master$`sparklyr.shell.driver-class-path` <- Sys.getenv("SPARK_DRIVER_CLASSPATH")
   }
 
-  if (is.null(spark_config_value(mergedConfig, c("sparklyr.connect.cores.local", "sparklyr.cores.local")))) {
+  if (is.null(spark_config_value(mergedConfig, c("sparklyr.cores.local", "sparklyr.connect.cores.local")))) {
     mergedConfig$sparklyr.connect.cores.local <- parallel::detectCores()
   }
 

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -72,7 +72,7 @@ spark_default_app_jar <- function(version, scala_version = NULL) {
 NULL
 
 spark_master_local_cores <- function(master, config) {
-  cores <- spark_config_value(config, c("sparklyr.connect.cores.local", "sparklyr.cores.local"))
+  cores <- spark_config_value(config, c("sparklyr.cores.local", "sparklyr.connect.cores.local"))
   if (master == "local" && !identical(cores, NULL)) {
     master <- paste("local[", cores, "]", sep = "")
   }


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>