### PR TITLE
Prepare for the updated `pivot_wider()` signature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -100,7 +100,7 @@ Imports:
     rstudioapi (>= 0.10),
     stringr,
     tibble,
-    tidyr (>= 0.3.0),
+    tidyr (>= 1.1.4.9000),
     tidyselect,
     uuid,
     vctrs,
@@ -123,6 +123,8 @@ Suggests:
     reshape2,
     shiny (>= 1.0.1),
     testthat
+Remotes:
+    tidyverse/tidyr
 Encoding: UTF-8
 RoxygenNote: 7.1.2
 SystemRequirements: Spark: 1.6.x, 2.x, or 3.x

--- a/R/tidyr_pivot_wider.R
+++ b/R/tidyr_pivot_wider.R
@@ -7,16 +7,33 @@ NULL
 #' @export
 pivot_wider.tbl_spark <- function(data,
                                   id_cols = NULL,
+                                  id_expand = FALSE,
                                   names_from = !!as.name("name"),
                                   names_prefix = "",
                                   names_sep = "_",
                                   names_glue = NULL,
                                   names_sort = FALSE,
+                                  names_vary = "fastest",
+                                  names_expand = FALSE,
                                   names_repair = "check_unique",
                                   values_from = !!as.name("value"),
                                   values_fill = NULL,
                                   values_fn = NULL,
+                                  unused_fn = NULL,
                                   ...) {
+  if (!identical(id_expand, FALSE)) {
+    rlang::abort("`id_expand` is not yet supported.")
+  }
+  if (!identical(names_vary, "fastest")) {
+    rlang::abort("`names_vary` is not yet supported.")
+  }
+  if (!identical(names_expand, FALSE)) {
+    rlang::abort("`names_expand` is not yet supported.")
+  }
+  if (!identical(unused_fn, NULL)) {
+    rlang::abort("`unused_fn` is not yet supported.")
+  }
+
   names_from <- rlang::enquo(names_from)
   values_from <- rlang::enquo(values_from)
   spec <- sdf_build_wider_spec(


### PR DESCRIPTION
CC @edgararuiz

We are planning to release tidyr 1.2.0 this week.

`pivot_wider()` gained 4 new arguments which you can read about [in the NEWS](https://github.com/tidyverse/tidyr/blob/main/NEWS.md#pivoting).

Unfortunately, because of an edge case in the way S3 method registration works, this causes sparklyr to break in revdep checking (in particular, this happens because of the specific combination of S3 issues outlined here https://github.com/DavisVaughan/methodtest).

There isn't anything we can do ahead of time to prevent sparklyr from breaking, but this PR is a first pass at preparing the `pivot_wider()` method for the next release. I've simply added the new arguments and then made them abort if they differ from their default value. Feel free to implement the behavior as you see fit.

Once tidyr is accepted, you should be able to bump the version requirement, remove the Remote, merge this, and then send a patch release to keep sparklyr from being removed from CRAN.