### PR TITLE
Remove usage of deprecated function

### DIFF
--- a/R/ml_feature_string_indexer.R
+++ b/R/ml_feature_string_indexer.R
@@ -80,7 +80,7 @@ ft_string_indexer.tbl_spark <- function(x, input_col = NULL, output_col = NULL,
   )
   # backwards compatibility for params argument
   dots <- rlang::dots_list(...)
-  if (rlang::has_name(dots, "params") && rlang::is_env(dots$params)) {
+  if (rlang::has_name(dots, "params") && is.environment(dots$params)) {
     warning("`params` has been deprecated and will be removed in a future release.", call. = FALSE)
     transformer <- if (is_ml_transformer(stage)) {
       stage


### PR DESCRIPTION
`is_env()` was deprecated in rlang 0.2.0 (released in 2018-02) and it looks like the code using it wasn't covered by unit tests (otherwise you'd have received deprecation warnings). We are removing this function from rlang 1.0.0, which causes sparklyr to fail R CMD check. Sorry I didn't catch this before, it looks like sparklyr isn't included in our cloud checks.