### PR TITLE
Addresses CRAN check results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: sparklyr
 Title: R Interface to Apache Spark
-Version: 1.7.4
+Version: 1.7.5
 Authors@R:
     c(person(given = "Javier",
              family = "Luraschi",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # sparklyr (development version)
 
+# Sparklyr 1.7.5
+
+### Misc
+
+- Addresses deprecation of `rlang::is_env()` function. (@lionel- #3217)
+
+- Updates `pivot_wider()` to support new version of `tidyr` (@DavisVaughan #3215)
+
 # Sparklyr 1.7.4
 
 ### Misc

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,29 @@
+## Release summary
+
+- Addresses both CRAN Check Results warnings:
+  - Un-exported object `rland::is_env()`
+  - `pivot_wider()` S3 consistency  issue
+  
+## Test environments
+
+- Local Mac OS M1 (aarch64-apple-darwin20), R 4.1.2
+- Ubuntu 20, R 4.0.5 (GH Actions)
+
+## R CMD check results
+
+0 errors ✓ | 0 warnings ✓ | 2 notes x
+
+Notes:
+
+```
+> checking package dependencies ... NOTE
+  Imports includes 31 non-default packages.
+```
+
+```
+> checking installed package size ... NOTE
+    installed size is  6.7Mb
+    sub-directories of 1Mb or more:
+      R      2.1Mb
+      java   3.4Mb
+```


### PR DESCRIPTION
## Summary

There are two current CRAN check results warnings that need to be addressed: https://cran.r-project.org/web/checks/check_results_sparklyr.html

Lionel and Davis submitted PRs to resolve the issues, which I already merged: 
- `rlang::is_env()` is no longer supported - PR #3217 
- `tidyr::pivot_wider()` interface changed in version 1.2.0 - PR #3215

I made some changes to PR #3215 to address GH Actions failures before merging.

## In this PR

- DESCRIPTION - Version bump to 1.7.5.  In PR #3215 the required version of `tidyr` is updated to >=1.2.0
- NEWS - Mentions the two new fixes
- cran-comments - Creates CRAN comments file confirming that the Warnings are gone, and recognizing the two pre-existing Notes