### PR TITLE
Change `pivot_longer()` argument defaults from `list()` to `NULL`

### DIFF
--- a/R/tidyr_pivot_longer.R
+++ b/R/tidyr_pivot_longer.R
@@ -11,13 +11,13 @@ pivot_longer.tbl_spark <- function(data,
                                    names_prefix = NULL,
                                    names_sep = NULL,
                                    names_pattern = NULL,
-                                   names_ptypes = list(),
-                                   names_transform = list(),
+                                   names_ptypes = NULL,
+                                   names_transform = NULL,
                                    names_repair = "check_unique",
                                    values_to = "value",
                                    values_drop_na = FALSE,
-                                   values_ptypes = list(),
-                                   values_transform = list(),
+                                   values_ptypes = NULL,
+                                   values_transform = NULL,
                                    ...) {
   cols <- rlang::enquo(cols)
   spec <- build_longer_spec(
@@ -135,8 +135,8 @@ sdf_pivot_longer <- function(data,
                              spec,
                              names_repair = "check_unique",
                              values_drop_na = FALSE,
-                             values_ptypes = list(),
-                             values_transform = list()) {
+                             values_ptypes = NULL,
+                             values_transform = NULL) {
   sc <- spark_connection(data)
   if (spark_version(sc) < "2.0.0") {
     rlang::abort("`pivot_wider.tbl_spark` requires Spark 2.0.0 or higher")


### PR DESCRIPTION
In tidyr 1.2.0 we updated `pivot_longer()`'s `names_transform`, `values_transform`, `names_ptypes` and `values_ptypes` arguments to allow a _single_ function or ptype which will be applied to all columns, rather than requiring a named list. See https://github.com/tidyverse/tidyr/blob/main/NEWS.md#pivoting

This required us to change the default argument from `list()` to `NULL`. In particular, for `names/values_ptypes`, this was important because `list()` should now be interpreted as "use a list ptype for all columns".

For backwards compatibility with sparklyr and a few other packages that extend `pivot_longer()`, we have temporarily forced `list()` to be interpreted as `NULL`, but we would like to remove this behavior. See https://github.com/tidyverse/tidyr/issues/1296.

This PR is a step towards that by updating the signature used in sparklyr to use `NULL` rather than `list()`. @edgararuiz I forgot to mention this to you before you sent in the sparklyr update, sorry about that. This one is less pressing though.

This may not work out of the box everywhere because you seem to handle these 4 arguments yourself rather than passing on to tidyr. Feel free to copy over the `check_list_of_ptypes()` and `check_list_of_functions()` helpers from tidyr that I added to help standardize these arguments https://github.com/tidyverse/tidyr/blob/60e4f2589e573d38c667a4bbf07822fd5fd9528b/R/pivot-long.R#L243-L244