### PR TITLE
Fixes #3276

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 # Sparklyr 1.7.7
 
+### dplyr
+
+- Makes sure to run previous `dplyr` actions before sampling (#3276)
+
 ### Misc
 
 - Ensures compatibility with the upcoming, and current, versions of `dbplyr`

--- a/R/dplyr_sql.R
+++ b/R/dplyr_sql.R
@@ -91,7 +91,7 @@ sql_build.op_sample <- function(op, con, frac) {
 #' @export
 sql_build.lazy_sample_query <- function(op, con, ...) {
   grps <- dbplyr::op_grps(op$x)
-  sdf <- to_sdf(op$x, con)
+  sdf <- to_sdf(op, con)
   frac <- op$frac
 
   if (rlang::quo_is_null(op$args$weight)) {

--- a/tests/testthat/test-dplyr-sample.R
+++ b/tests/testthat/test-dplyr-sample.R
@@ -38,3 +38,24 @@ test_that("set.seed makes sampling outcomes deterministic", {
     }
   }
 })
+
+test_that("dplyr query is executed before sampling", {
+
+  expect_equal(
+    testthat_tbl("mtcars") %>%
+      select(hp, mpg) %>%
+      sample_n(5) %>%
+      collect() %>%
+      dim(),
+    c(5, 2)
+  )
+
+  expect_equal(
+    testthat_tbl("mtcars") %>%
+      select(hp, mpg) %>%
+      sample_frac(0.1) %>%
+      collect() %>%
+      dim(),
+    c(3, 2)
+  )
+})


### PR DESCRIPTION
- Fixes #3276 
- Ensures that previous `dplyr` actions run before sampling. The change was to pass the full `op` var to `to_sdf()`. The main sampling function was the only one passing `op$x` and not `op` like the other times that command is called
- Adds a couple of tests to make sure we don't loose that functionality
- Updates news