### PR TITLE
CRAN release prep. Version bump, revdeps refresh, updates news 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: sparklyr
 Title: R Interface to Apache Spark
-Version: 1.7.7.9001
+Version: 1.7.8
 Authors@R:
     c(person(given = "Javier",
              family = "Luraschi",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,64 @@
-# Sparklyr - dev
+# Sparklyr 1.7.8
 
-### Misc
+### New features
 
-- Addresses new CRAN HTML checks
+- Adds new metric extraction functions: `ml_metrics_binary()`, 
+  `ml_metrics_regression()` and `ml_metrics_multiclass()`. They work closer to 
+  how `yardstick` metric extraction functions work. They expect a table with 
+  the predictions and actual values, and returns a concise `tibble` with the 
+  metrics. (#3281)
+  
+- Adds new `spark_insert_table()` function. This allows one to insert data into 
+  an existing table definition without redefining the table, even when overwriting 
+  the existing data. (#3272 @jimhester)
 
-- Adds new metric extraction functions: `ml_metrics_binary()`, `ml_metrics_regression()` 
-and `ml_metrics_multiclass()`. They work closer to how `yardstick` metric extraction
-functions work. They expect a table with the predictions and actual values, and returns
-a concise `tibble` with the metrics.  
+### Bug Fixes
 
-- Adds support to Spark 3.3 
+- Restores "validator" functions to regression models. Removing them in a previous
+  version broke `ml_cross_validator()` for regression models. (#3273)
+
+### Spark 
+
+- Adds support to Spark 3.3 local installation. This includes the ability to 
+  enable and setup log4j version 2. (#3269)
+
+- Updates the JSON file that `sparklyr` uses to find and download Spark for
+  local use.  It is worth mentioning that starting with Spark 3.3, the Hadoop
+  version number is no longer using a minor version for its download link. So, 
+  instead of requesting 3.2, the version to request is 3. 
+
+### Internal functionality
+
+- Removes workaround for older versions of `arrow`. Bumps `arrow` version 
+  dependency, from 0.14.0 to 0.17.0 (#3283 @nealrichardson)
 
 - Removes code related to backwards compatibility with `dbplyr`. `sparklyr`
   requires `dbplyr` version 2.2.1 or above, so the code is no longer needed. 
+  (#3277)
+
+- Begins centralizing ML parameter validation into a single function that will
+  run the proper `cast` function for each Spark parameter.  It also starts using
+  S3 methods, instead of searching for a concatenated function name, to find the
+  proper parameter validator.  Regression models are the first ones to use this
+  new method. (#3279)
+
+- `sparklyr` compilation routines have been improved and simplified.  
+  `spark_compile()` now provides more informative output when used.  It also adds
+  tests to compilation to make sure. It also adds a step to install Scala in the 
+  corresponding GHAs. This is so that the new JAR build tests are able to run. 
+  (#3275)
+
+- Stops using package environment variables directly. Any package level variable
+  will be handled by a `genv` prefixed function to set and retrieve values.  This
+  avoids the risk of having the exact same variable initialized on more than on
+  R script. (#3274)
+
+- Adds more tests to improve coverage.
+
+### Misc
+
+- Addresses new CRAN HTML check NOTEs. It also adds a new GHA action to run the 
+  same checks to make sure we avoid new issues with this in the future.
 
 # Sparklyr 1.7.7
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,25 +1,85 @@
-## Patch Re-submission
+# Submission
 
-### Release summary
+## Release summary
 
-- Restores missing 'java' folder 
+### Misc
+
+- Addresses new CRAN HTML check NOTEs. It also adds a new GHA action to run the 
+  same checks to make sure we avoid new issues with this in the future.
+
+### New features
+
+- Adds new metric extraction functions: `ml_metrics_binary()`, 
+  `ml_metrics_regression()` and `ml_metrics_multiclass()`. They work closer to 
+  how `yardstick` metric extraction functions work. They expect a table with 
+  the predictions and actual values, and returns a concise `tibble` with the 
+  metrics. (#3281)
   
-### Test environments
+- Adds new `spark_insert_table()` function. This allows one to insert data into 
+  an existing table definition without redefining the table, even when overwriting 
+  the existing data. (#3272 @jimhester)
 
-- Ubuntu 20.04, R 4.2.0, Spark 3.2 (GH Actions)
-- Ubuntu 20.04, R 4.2.0, Spark 3.1 (GH Actions)
-- Ubuntu 20.04, R 4.2.0, Spark 2.4 (GH Actions)
-- Ubuntu 20.04, R 4.2.0, Spark 2.2 (GH Actions)
+### Bug Fixes
+
+- Restores "validator" functions to regression models. Removing them in a previous
+  version broke `ml_cross_validator()` for regression models. (#3273)
+
+### Spark 
+
+- Adds support to Spark 3.3 local installation. This includes the ability to 
+  enable and setup log4j version 2. (#3269)
+
+- Updates the JSON file that `sparklyr` uses to find and download Spark for
+  local use.  It is worth mentioning that starting with Spark 3.3, the Hadoop
+  version number is no longer using a minor version for its download link. So, 
+  instead of requesting 3.2, the version to request is 3. 
+
+### Internal functionality
+
+- Removes workaround for older versions of `arrow`. Bumps `arrow` version 
+  dependency, from 0.14.0 to 0.17.0 (#3283 @nealrichardson)
+
+- Removes code related to backwards compatibility with `dbplyr`. `sparklyr`
+  requires `dbplyr` version 2.2.1 or above, so the code is no longer needed. 
+  (#3277)
+
+- Begins centralizing ML parameter validation into a single function that will
+  run the proper `cast` function for each Spark parameter.  It also starts using
+  S3 methods, instead of searching for a concatenated function name, to find the
+  proper parameter validator.  Regression models are the first ones to use this
+  new method. (#3279)
+
+- `sparklyr` compilation routines have been improved and simplified.  
+  `spark_compile()` now provides more informative output when used.  It also adds
+  tests to compilation to make sure. It also adds a step to install Scala in the 
+  corresponding GHAs. This is so that the new JAR build tests are able to run. 
+  (#3275)
+
+- Stops using package environment variables directly. Any package level variable
+  will be handled by a `genv` prefixed function to set and retrieve values.  This
+  avoids the risk of having the exact same variable initialized on more than on
+  R script. (#3274)
+
+- Adds more tests to improve coverage.
+
+
+## Test environments
+
+- Ubuntu 20.04, R 4.2.1, Spark 3.3 (GH Actions)
+- Ubuntu 20.04, R 4.2.1, Spark 3.2 (GH Actions)
+- Ubuntu 20.04, R 4.2.1, Spark 3.1 (GH Actions)
+- Ubuntu 20.04, R 4.2.1, Spark 2.4 (GH Actions)
+- Ubuntu 20.04, R 4.2.1, Spark 2.2 (GH Actions)
   
-### R CMD check environments
+## R CMD check environments
 
-- Local Mac OS M1 (aarch64-apple-darwin20), R 4.2.0
-- Mac OS x86_64-apple-darwin17.0 (64-bit), R 4.2.0
-- Windows  x86_64-w64-mingw32 (64-bit), R 4.2.0
-- Linux x86_64-pc-linux-gnu (64-bit), R 4.2.0
+- Local Mac OS M1 (aarch64-apple-darwin20), R 4.2.1
+- Mac OS x86_64-apple-darwin17.0 (64-bit), R 4.2.1
+- Windows  x86_64-w64-mingw32 (64-bit), R 4.2.1
+- Linux x86_64-pc-linux-gnu (64-bit), R 4.2.1
 
 
-### R CMD check results
+## R CMD check results
 
 0 errors ✓ | 0 warnings ✓ | 2 notes x
 
@@ -27,7 +87,7 @@ Notes:
 
 ```
 ❯ checking package dependencies ... NOTE
-  Imports includes 29 non-default packages.
+  Imports includes 28 non-default packages.
   Importing from so many packages makes the package vulnerable to any of
   them becoming unavailable.  Move as many as possible to Suggests and
   use conditionally.
@@ -37,12 +97,17 @@ Notes:
     sub-directories of 1Mb or more:
       R      2.0Mb
       java   3.4Mb
+
 ```
 
-### Reverse dependencies
+###Reverse dependencies
 
 |Package|Version|Error|Warning|Note|OK|
 |:---|:---|:---|:---|:---|:---|
+|[apache.sedona](#apache.sedona)|1.1.1|0|0|1|39|
+|[catalog](#catalog)|0.1.0|0|0|1|42|
+|[geospark](#geospark)|0.3.1|0|0|2|41|
+|[graphframes](#graphframes)|0.1.2|0|0|1|42|
 |[apache.sedona](#apache.sedona)|1.1.1|0|0|1|39|
 |[catalog](#catalog)|0.1.0|0|0|1|42|
 |[geospark](#geospark)|0.3.1|0|0|2|41|
@@ -60,3 +125,17 @@ Notes:
 |[sparkwarc](#sparkwarc)|0.1.6|0|0|0|47|
 |[sparkxgb](#sparkxgb)|0.1.1|0|0|1|41|
 |[variantspark](#variantspark)|0.1.1|0|0|1|42|
+|[rsparkling](#rsparkling)|0.2.19|0|0|2|33|
+|[s3.resourcer](#s3.resourcer)|1.0.1|0|0|0|41|
+|[shinyML](#shinyML)|1.0.1|0|0|1|40|
+|[spark.sas7bdat](#spark.sas7bdat)|1.4|0|0|0|46|
+|[sparkavro](#sparkavro)|0.3.0|0|0|1|42|
+|[sparkbq](#sparkbq)|0.1.1|0|0|1|40|
+|[sparkhail](#sparkhail)|0.1.1|0|0|1|42|
+|[sparklyr.flint](#sparklyr.flint)|0.2.2|0|0|0|46|
+|[sparklyr.nested](#sparklyr.nested)|0.0.3|0|0|1|41|
+|[sparktf](#sparktf)|0.1.0|0|0|1|42|
+|[sparkwarc](#sparkwarc)|0.1.6|0|0|0|47|
+|[sparkxgb](#sparkxgb)|0.1.1|0|0|1|41|
+|[variantspark](#variantspark)|0.1.1|0|0|1|42|
+

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -6,6 +6,23 @@
 |[catalog](#catalog)|0.1.0|0|0|1|42|
 |[geospark](#geospark)|0.3.1|0|0|2|41|
 |[graphframes](#graphframes)|0.1.2|0|0|1|42|
+|[apache.sedona](#apache.sedona)|1.1.1|0|0|1|39|
+|[catalog](#catalog)|0.1.0|0|0|1|42|
+|[geospark](#geospark)|0.3.1|0|0|2|41|
+|[graphframes](#graphframes)|0.1.2|0|0|1|42|
+|[rsparkling](#rsparkling)|0.2.19|0|0|2|33|
+|[s3.resourcer](#s3.resourcer)|1.0.1|0|0|0|41|
+|[shinyML](#shinyML)|1.0.1|0|0|1|40|
+|[spark.sas7bdat](#spark.sas7bdat)|1.4|0|0|0|46|
+|[sparkavro](#sparkavro)|0.3.0|0|0|1|42|
+|[sparkbq](#sparkbq)|0.1.1|0|0|1|40|
+|[sparkhail](#sparkhail)|0.1.1|0|0|1|42|
+|[sparklyr.flint](#sparklyr.flint)|0.2.2|0|0|0|46|
+|[sparklyr.nested](#sparklyr.nested)|0.0.3|0|0|1|41|
+|[sparktf](#sparktf)|0.1.0|0|0|1|42|
+|[sparkwarc](#sparkwarc)|0.1.6|0|0|0|47|
+|[sparkxgb](#sparkxgb)|0.1.1|0|0|1|41|
+|[variantspark](#variantspark)|0.1.1|0|0|1|42|
 |[rsparkling](#rsparkling)|0.2.19|0|0|2|33|
 |[s3.resourcer](#s3.resourcer)|1.0.1|0|0|0|41|
 |[shinyML](#shinyML)|1.0.1|0|0|1|40|
@@ -23,8 +40,8 @@
 ## Details
 ###  apache.sedona
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/apache.sedona.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/apache.sedona.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -40,8 +57,8 @@ Status: 1 NOTE
 
 ###  catalog
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/catalog.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/catalog.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -56,8 +73,8 @@ Status: 1 NOTE
 
 ###  geospark
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/geospark.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/geospark.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -75,8 +92,76 @@ Status: 2 NOTEs
 
 ###  graphframes
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/graphframes.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/graphframes.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘graphframes’ version ‘0.1.2’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+  Running ‘testthat.R’
+* DONE
+Status: 1 NOTE
+```
+
+###  apache.sedona
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/apache.sedona.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘apache.sedona’ version ‘1.1.1’
+* package encoding: UTF-8
+* checking dependencies in R code ... NOTE
+Namespaces in Imports field not imported from:
+  ‘DBI’ ‘dplyr’
+  All declared Imports should be used.
+* DONE
+Status: 1 NOTE
+```
+
+###  catalog
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/catalog.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘catalog’ version ‘0.1.0’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+  Running ‘tinytest.R’
+* DONE
+Status: 1 NOTE
+```
+
+###  geospark
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/geospark.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘geospark’ version ‘0.3.1’
+* package encoding: UTF-8
+* checking dependencies in R code ... NOTE
+Namespace in Imports field not imported from: ‘dbplyr’
+  All declared Imports should be used.
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+  Running ‘testthat.R’
+* DONE
+Status: 2 NOTEs
+```
+
+###  graphframes
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/graphframes.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -91,8 +176,8 @@ Status: 1 NOTE
 
 ###  rsparkling
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/rsparkling.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/rsparkling.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * this is package ‘rsparkling’ version ‘0.2.19’
@@ -110,8 +195,8 @@ Status: 2 NOTEs
 
 ###  s3.resourcer
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/s3.resourcer.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/s3.resourcer.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -125,8 +210,8 @@ Status: OK
 
 ###  shinyML
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/shinyML.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/shinyML.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -140,8 +225,8 @@ Status: 1 NOTE
 
 ###  spark.sas7bdat
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/spark.sas7bdat.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/spark.sas7bdat.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -154,8 +239,8 @@ Status: OK
 
 ###  sparkavro
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/sparkavro.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkavro.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -170,8 +255,8 @@ Status: 1 NOTE
 
 ###  sparkbq
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/sparkbq.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkbq.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -185,8 +270,8 @@ Status: 1 NOTE
 
 ###  sparkhail
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/sparkhail.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkhail.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -201,8 +286,8 @@ Status: 1 NOTE
 
 ###  sparklyr.flint
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/sparklyr.flint.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparklyr.flint.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -210,7 +295,7 @@ Status: 1 NOTE
 * package encoding: UTF-8
 Examples with CPU (user + system) or elapsed time > 5s
                        user system elapsed
-asof_future_left_join 0.343  0.063  19.533
+asof_future_left_join 0.392  0.106  20.612
 * checking running R code from vignettes ... NONE
   ‘importing-time-series-data.Rmd’ using ‘UTF-8’... OK
   ‘overview.Rmd’ using ‘UTF-8’... OK
@@ -221,8 +306,8 @@ Status: OK
 
 ###  sparklyr.nested
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/sparklyr.nested.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparklyr.nested.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * this is package ‘sparklyr.nested’ version ‘0.0.3’
@@ -236,8 +321,8 @@ Status: 1 NOTE
 
 ###  sparktf
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/sparktf.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparktf.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -252,8 +337,8 @@ Status: 1 NOTE
 
 ###  sparkwarc
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/sparkwarc.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkwarc.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -265,8 +350,8 @@ Status: OK
 
 ###  sparkxgb
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/sparkxgb.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkxgb.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package
@@ -282,8 +367,215 @@ Status: 1 NOTE
 
 ###  variantspark
 ```
-* using log directory ‘/Users/edgar/r_projects/sparklyr-gh/revdep/variantspark.Rcheck’
-* using R version 4.2.0 (2022-04-22)
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/variantspark.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘variantspark’ version ‘0.1.1’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+  Running ‘testthat.R’
+* DONE
+Status: 1 NOTE
+```
+
+###  rsparkling
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/rsparkling.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* this is package ‘rsparkling’ version ‘0.2.19’
+* package encoding: UTF-8
+* checking dependencies in R code ... NOTE
+Namespace in Imports field not imported from: ‘h2o’
+  All declared Imports should be used.
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+* checking examples ... NONE
+  Running ‘testthat.R’
+* DONE
+Status: 2 NOTEs
+```
+
+###  s3.resourcer
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/s3.resourcer.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘s3.resourcer’ version ‘1.0.1’
+* package encoding: UTF-8
+* checking examples ... NONE
+  Running ‘testthat.R’
+* DONE
+Status: OK
+```
+
+###  shinyML
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/shinyML.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘shinyML’ version ‘1.0.1’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+* DONE
+Status: 1 NOTE
+```
+
+###  spark.sas7bdat
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/spark.sas7bdat.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘spark.sas7bdat’ version ‘1.4’
+* checking running R code from vignettes ... NONE
+  ‘spark_sas7bdat_examples.Rmd’ using ‘UTF-8’... OK
+* DONE
+Status: OK
+```
+
+###  sparkavro
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkavro.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘sparkavro’ version ‘0.3.0’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+  Running ‘testthat.R’
+* DONE
+Status: 1 NOTE
+```
+
+###  sparkbq
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkbq.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘sparkbq’ version ‘0.1.1’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+* DONE
+Status: 1 NOTE
+```
+
+###  sparkhail
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkhail.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘sparkhail’ version ‘0.1.1’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+  Running ‘testthat.R’
+* DONE
+Status: 1 NOTE
+```
+
+###  sparklyr.flint
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparklyr.flint.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘sparklyr.flint’ version ‘0.2.2’
+* package encoding: UTF-8
+Examples with CPU (user + system) or elapsed time > 5s
+                       user system elapsed
+asof_future_left_join 0.394  0.108  21.096
+* checking running R code from vignettes ... NONE
+  ‘importing-time-series-data.Rmd’ using ‘UTF-8’... OK
+  ‘overview.Rmd’ using ‘UTF-8’... OK
+  ‘working-with-time-series-rdd.Rmd’ using ‘UTF-8’... OK
+* DONE
+Status: OK
+```
+
+###  sparklyr.nested
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparklyr.nested.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* this is package ‘sparklyr.nested’ version ‘0.0.3’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+  Running ‘testthat.R’
+* DONE
+Status: 1 NOTE
+```
+
+###  sparktf
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparktf.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘sparktf’ version ‘0.1.0’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+  Running ‘testthat.R’
+* DONE
+Status: 1 NOTE
+```
+
+###  sparkwarc
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkwarc.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘sparkwarc’ version ‘0.1.6’
+* package encoding: UTF-8
+* DONE
+Status: OK
+```
+
+###  sparkxgb
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/sparkxgb.Rcheck’
+* using R version 4.2.1 (2022-06-23)
+* using platform: aarch64-apple-darwin20 (64-bit)
+* using session charset: UTF-8
+* checking extension type ... Package
+* this is package ‘sparkxgb’ version ‘0.1.1’
+* package encoding: UTF-8
+* checking LazyData ... NOTE
+  'LazyData' is specified without a 'data' directory
+* checking examples ... NONE
+  Running ‘testthat.R’
+* DONE
+Status: 1 NOTE
+```
+
+###  variantspark
+```
+* using log directory ‘/Users/edgar/r_projects/sparklyr/revdep/variantspark.Rcheck’
+* using R version 4.2.1 (2022-06-23)
 * using platform: aarch64-apple-darwin20 (64-bit)
 * using session charset: UTF-8
 * checking extension type ... Package


### PR DESCRIPTION
## On this release:

### Misc

- Addresses new CRAN HTML check NOTEs (https://cran.r-project.org/web/checks/check_results_sparklyr.html.). It also adds a new GHA action to run the 
  same checks to make sure we avoid new issues with this in the future.

### New features

- Adds new metric extraction functions: `ml_metrics_binary()`, 
  `ml_metrics_regression()` and `ml_metrics_multiclass()`. They work closer to 
  how `yardstick` metric extraction functions work. They expect a table with 
  the predictions and actual values, and returns a concise `tibble` with the 
  metrics. (#3281)
  
- Adds new `spark_insert_table()` function. This allows one to insert data into 
  an existing table definition without redefining the table, even when overwriting 
  the existing data. (#3272 @jimhester)

### Bug Fixes

- Restores "validator" functions to regression models. Removing them in a previous
  version broke `ml_cross_validator()` for regression models. (#3273)

### Spark 

- Adds support to Spark 3.3 local installation. This includes the ability to 
  enable and setup log4j version 2. (#3269)

- Updates the JSON file that `sparklyr` uses to find and download Spark for
  local use.  It is worth mentioning that starting with Spark 3.3, the Hadoop
  version number is no longer using a minor version for its download link. So, 
  instead of requesting 3.2, the version to request is 3. 

### Internal functionality

- Removes workaround for older versions of `arrow`. Bumps `arrow` version 
  dependency, from 0.14.0 to 0.17.0 (#3283 @nealrichardson)

- Removes code related to backwards compatibility with `dbplyr`. `sparklyr`
  requires `dbplyr` version 2.2.1 or above, so the code is no longer needed. 
  (#3277)

- Begins centralizing ML parameter validation into a single function that will
  run the proper `cast` function for each Spark parameter.  It also starts using
  S3 methods, instead of searching for a concatenated function name, to find the
  proper parameter validator.  Regression models are the first ones to use this
  new method. (#3279)

- `sparklyr` compilation routines have been improved and simplified.  
  `spark_compile()` now provides more informative output when used.  It also adds
  tests to compilation to make sure. It also adds a step to install Scala in the 
  corresponding GHAs. This is so that the new JAR build tests are able to run. 
  (#3275)

- Stops using package environment variables directly. Any package level variable
  will be handled by a `genv` prefixed function to set and retrieve values.  This
  avoids the risk of having the exact same variable initialized on more than on
  R script. (#3274)

- Adds more tests to improve coverage.
