### PR TITLE
Adding support for 3 tier namespaces `<catalog>.<schema>.<table>`

### DIFF
--- a/R/dplyr_spark.R
+++ b/R/dplyr_spark.R
@@ -138,8 +138,10 @@ process_tbl_name <- function(x) {
         x
       } else if (identical(num_components, 2L)) {
         dbplyr::in_schema(components[[1]], components[[2]])
+      } else if (identical(num_components, 3L)) {
+        dbplyr::in_catalog(components[[1]], components[[2]], components[[3]])
       } else {
-        stop("expected input to be <table name> or <schema name>.<table name>")
+        stop("expected input to be <table name>, <schema name>.<table name>, or <catalog name>.<schema name>.<table name>")
       }
     }
   }

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -442,6 +442,7 @@ test_that("process_tbl_name works as expected", {
   expect_equal(sparklyr:::process_tbl_name("a"), "a")
   expect_equal(sparklyr:::process_tbl_name("xyz"), "xyz")
   expect_equal(sparklyr:::process_tbl_name("x.y"), dbplyr::in_schema("x", "y"))
+  expect_equal(sparklyr:::process_tbl_name("x.y.z"), dbplyr::in_catalog("x", "y", "z"))
 
   df1 <- tibble::tibble(a = 1, g = 2) %>%
     copy_to(sc, ., "df1", overwrite = TRUE)


### PR DESCRIPTION
Adjusting the `process_tbl_name()` function to support 3 tier namespaces.

Small change, works on Databricks when built and tested - this is required for those who wish to use 'Unity Catalog' which has a 3 tier namespace.

Currently there are no tests specific to `spark_read_table()` only `spark_write_table()`.
Happy to take guidance on tests that should be added (if any).

Signed-off-by: Zac Davies <zac@databricks.com>