### PR TITLE
Fixing test cases

### DIFF
--- a/tests/testthat/test-dplyr-distinct.R
+++ b/tests/testthat/test-dplyr-distinct.R
@@ -24,10 +24,10 @@ test_that("distinct for single column works as expected", {
   )
   sdf <- copy_to(sc, df, name = random_string("tmp"))
   expect_equivalent(
-    sdf %>% dplyr::distinct(x, .keep_all = FALSE) %>% collect(), unique(df["x"])
+    sdf %>% dplyr::distinct(x, .keep_all = FALSE) %>% arrange(x) %>% collect(), unique(df[order(df$x),"x"])
   )
   expect_equivalent(
-    sdf %>% dplyr::distinct(y, .keep_all = FALSE) %>% collect(), unique(df["y"])
+    sdf %>% dplyr::distinct(y, .keep_all = FALSE) %>% arrange(y) %>% collect(), unique(df[order(df$y), "y"])
   )
 })
 
@@ -77,7 +77,7 @@ test_that("grouped distinct always includes group cols", {
     group_by(g) %>%
     distinct(x)
 
-  expect_equivalent(out %>% collect(), tibble::tibble(g = c(1, 2), x = c(1, 2)))
+  expect_equivalent(out %>% arrange(g) %>% collect(), tibble::tibble(g = c(1, 2), x = c(1, 2)))
   expect_equal(dplyr::group_vars(out), "g")
 })
 
@@ -110,7 +110,7 @@ test_that("distinct on a new, copied variable is equivalent to mutate followed b
   sdf <- copy_to(sc, tibble::tibble(g = c(1, 2), x = c(1, 2)))
 
   expect_equivalent(
-    sdf %>% dplyr::distinct(aa = g) %>% collect(), tibble::tibble(aa = c(1, 2))
+    sdf %>% dplyr::distinct(aa = g) %>% arrange(aa) %>% collect(), tibble::tibble(aa = c(1, 2))
   )
 })
 
@@ -122,8 +122,8 @@ test_that("distinct preserves grouping", {
   sdf <- sdf1 %>% dplyr::group_by(x)
 
   expect_equivalent(
-    sdf %>% dplyr::distinct(x) %>% collect(),
-     df %>% dplyr::distinct(x)
+    sdf %>% dplyr::distinct(x) %>% arrange(x) %>% collect(),
+     df %>% dplyr::distinct(x) %>% arrange(x)
     )
 
   expect_equivalent(

--- a/tests/testthat/test-dplyr-top-n.R
+++ b/tests/testthat/test-dplyr-top-n.R
@@ -1,8 +1,8 @@
 skip_on_livy()
 sc <- testthat_spark_connection()
 
-test_that("top_n works as expected", {
-  skip("skip while dbplyr/#330 is investigated")
+test_that("slice_max works as expected", {
+  # skip("skip while dbplyr/#330 is investigated")
 
   test_requires_version("2.0.0", "bug in spark-csv")
   test_requires("dplyr")
@@ -13,16 +13,16 @@ test_that("top_n works as expected", {
     test_data <- c(test_data, rep.int(LETTERS[i], times = i * 10))
   }
 
-  test_data <- data.frame("X" = test_data, stringsAsFactors = F)
+  test_data <- tibble("X" = test_data, stringsAsFactors = F)
   test_tbl <- copy_to(sc, test_data)
 
   tn1 <- test_tbl %>%
     count(X) %>%
-    top_n(10) %>%
+    slice_max(n = 10, order_by = n) %>%
     collect()
   tn2 <- test_data %>%
     count(X) %>%
-    top_n(10)
+    slice_max(n = 10, order_by = n)
 
   tn2 <- tn2 %>%
     mutate(n = as.integer(n)) %>%

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -518,10 +518,13 @@ test_that("summarise(.groups=)", {
       sdf %>%
         group_by(val1) %>%
         summarize(result = sum(val2, na.rm = TRUE), .groups = groups) %>%
+        arrange(val1) %>%
         collect(),
       df %>%
         group_by(val1) %>%
-        summarize(result = sum(val2, na.rm = TRUE), .groups = groups)
+        summarize(result = sum(val2, na.rm = TRUE), .groups = groups) %>%
+        arrange(val1)
+
     )
   }
 })

--- a/tests/testthat/test-spark-apply.R
+++ b/tests/testthat/test-spark-apply.R
@@ -131,7 +131,7 @@ test_that("'spark_apply' supports nested lists as input type", {
   }
 
   expect_equivalent(
-    spark_apply(sdf, fn) %>% collect(),
+    spark_apply(sdf, fn) %>% arrange(a) %>% collect(),
     tibble::tibble(a = c(1, 1, 1, 2, 2), b = 2)
   )
 })

--- a/tests/testthat/test-tidyr-pivot-wider.R
+++ b/tests/testthat/test-tidyr-pivot-wider.R
@@ -144,10 +144,12 @@ test_that("can override default keys", {
   sdf <- copy_to(sc, df, overwrite = TRUE)
 
   df_pw <- df %>%
-    pivot_wider(id_cols = name, names_from = var, values_from = value)
+    pivot_wider(id_cols = name, names_from = var, values_from = value) %>%
+    arrange(name)
 
   sdf_pw <- sdf %>%
     pivot_wider(id_cols = name, names_from = var, values_from = value) %>%
+    arrange(name) %>%
     collect()
 
   expect_equal(
@@ -338,10 +340,10 @@ test_that("Simple cases work", {
     tidyr::pivot_wider(head(d, 2), id_cols = c(c1, c2), names_from = c3, values_from = c(c4, c5))
   )
 
-  skip("Failing on GH, needs investigation")
+  # skip("Failing on GH, needs investigation")
   expect_equal(
-    collect(pivot_wider(ds, id_cols = c(c1, c2), names_from = c3, values_from = c(c4, c5))),
-    tidyr::pivot_wider(d, id_cols = c(c1, c2), names_from = c3, values_from = c(c4, c5))
+    collect(pivot_wider(ds, id_cols = c(c1, c2), names_from = c3, values_from = c(c4, c5), names_sort = TRUE)),
+    tidyr::pivot_wider(d, id_cols = c(c1, c2), names_from = c3, values_from = c(c4, c5), names_sort = TRUE)
   )
 
 })


### PR DESCRIPTION
Fixes test cases that were failing mainly because the ordering of rows is not preserved.
Not sure why this is not an issue with the GH test, but was on my machine (MacOS)

Also replacing top_n test with newer slice_max.
