### PR TITLE
Fix early return on batch jobs

### DIFF
--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -440,7 +440,7 @@ start_shell <- function(master,
   }
 
   # batch connections only use the shell to submit an application, not to connect.
-  if (identical(batch, TRUE)) {
+  if (identical(isBatch, TRUE)) {
     return(NULL)
   }
 


### PR DESCRIPTION
Early return on `isBatch`, which is the logical value, instead of `batch`, while is the file name. Closes #3311. 