### PR TITLE
Addresses multi-level table names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: sparklyr
 Title: R Interface to Apache Spark
-Version: 1.8.2.9003
+Version: 1.8.2.9004
 Authors@R:
     c(person(given = "Javier",
              family = "Luraschi",

--- a/R/dbi_spark_connection.R
+++ b/R/dbi_spark_connection.R
@@ -61,7 +61,11 @@ dbi_ensure_no_backtick <- function(x) {
 
 setMethod("dbQuoteIdentifier", c("spark_connection", "character"), function(conn, x, ...) {
   split_x <- unlist(strsplit(x, "\\."))
-  if (length(x) == 0L | inherits(x, "ident") | length(split_x) > 1) {
+  possible_schema <- FALSE
+  if(length(split_x) > 1) {
+    if(!any(split_x == "")) possible_schema <- TRUE
+  }
+  if (length(x) == 0L | inherits(x, "ident") | possible_schema) {
     out <- x
   } else {
     dbi_ensure_no_backtick(x)

--- a/R/dbi_spark_connection.R
+++ b/R/dbi_spark_connection.R
@@ -54,19 +54,21 @@ get_data_type <- function(obj) {
 }
 
 dbi_ensure_no_backtick <- function(x) {
-  if (regexpr("`", x)[[1]] >= 0) stop("Can't escape back tick from string")
+  if (regexpr("`", x)[[1]] >= 0) {
+    stop("Can't escape back tick from string")
+  }
 }
 
 setMethod("dbQuoteIdentifier", c("spark_connection", "character"), function(conn, x, ...) {
-  if (length(x) == 0L) {
-    x
+  split_x <- unlist(strsplit(x, "\\."))
+  if (length(x) == 0L | inherits(x, "ident") | length(split_x) > 1) {
+    out <- x
   } else {
     dbi_ensure_no_backtick(x)
-
     y <- paste("`", x, "`", sep = "")
-
-    SQL(y)
+    out <- SQL(y)
   }
+  out
 })
 
 setMethod("dbQuoteString", c("spark_connection", "character"), function(conn, x, ...) {

--- a/R/dbi_spark_connection.R
+++ b/R/dbi_spark_connection.R
@@ -65,7 +65,10 @@ setMethod("dbQuoteIdentifier", c("spark_connection", "character"), function(conn
   if(length(split_x) > 1) {
     if(!any(split_x == "")) possible_schema <- TRUE
   }
-  if (length(x) == 0L | inherits(x, "ident") | possible_schema) {
+  if (length(x) == 0L |
+      (inherits(x, "ident") && possible_schema) |
+      (regexpr("`", x)[[1]] >= 0 && possible_schema)
+      ) {
     out <- x
   } else {
     dbi_ensure_no_backtick(x)

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -16,15 +16,18 @@ spark_install_version_expand <- function(version, installed_only) {
     versions <- spark_available_versions(show_minor = TRUE)$spark
   }
 
-  versions <- versions[grepl(version, versions)]
+  sub_versions <- substr(versions, 1, nchar(version))
+
+  versions <- versions[version == sub_versions]
 
   if (length(versions) > 0) {
-    sort(versions, decreasing = TRUE)[1]
+    out <- sort(versions, decreasing = TRUE)[1]
   } else {
     # If the version specified is not a known available version, then don't
     # attempt to exapnd it.
-    version
+    out <- version
   }
+  out
 }
 
 #' Find a given Spark installation by version.


### PR DESCRIPTION
- Adds ability to handle multi-level table names, usually provided by `dbplyr`'s `in_catalog()`, and `in_schema()`