### PR TITLE
fix `print.tbl_spark()` with `tbl_pyspark`

### DIFF
--- a/R/dbi_spark_connection.R
+++ b/R/dbi_spark_connection.R
@@ -65,10 +65,9 @@ setMethod("dbQuoteIdentifier", c("spark_connection", "character"), function(conn
   if(length(split_x) > 1) {
     if(!any(split_x == "")) possible_schema <- TRUE
   }
-  if (length(x) == 0L |
-      (inherits(x, "ident") && possible_schema) |
-      (regexpr("`", x)[[1]] >= 0 && possible_schema)
-      ) {
+  if (length(x) == 0L ||
+      (inherits(x, "ident") && possible_schema) ||
+      (regexpr("`", x)[[1]] >= 0 && possible_schema)) {
     out <- x
   } else {
     dbi_ensure_no_backtick(x)


### PR DESCRIPTION
`x` in this funciton can be a length-0 character vector (as encountered in pysparklyr)
In that case, printing a tbl results in error:
```
Error in regexpr("`", x)[[1]] : subscript out of bounds
```
This patch fixes the error.