### PR TITLE
Update winutils to 3.0.0

### DIFF
--- a/R/install_spark_windows.R
+++ b/R/install_spark_windows.R
@@ -164,7 +164,7 @@ winutils_source_path <- function() {
 
 stop_with_winutils_error <- function(hadoopBinPath) {
   if (is_win64()) {
-    winutilsDownload <- "https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.0/bin/"
+    winutilsDownload <- "https://github.com/steveloughran/winutils/raw/master/hadoop-3.0.0/bin/"
   } else {
     winutilsDownload <- "https://code.google.com/archive/p/rrd-hadoop-win32/source/default/source"
   }


### PR DESCRIPTION
Hi! I just installed for the first time on windows, and I got the following output:
```
> sparklyr::spark_install()
Installing Spark 3.5.0 for Hadoop 3 or later.
Downloading from:
- 'https://dlcdn.apache.org/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz'
Installing to:
- 'C:\Users\th798\AppData\Local/spark/spark-3.5.0-bin-hadoop3'
trying URL 'https://dlcdn.apache.org/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz'
Content type 'application/x-gzip' length 400395283 bytes (381.8 MB)
downloaded 381.8 MB

Installation complete.
> sc=sparklyr::spark_connect(master="local")
* Using Spark: 3.5.0
Error: 

To run Spark on Windows you need a copy of Hadoop winutils.exe:

1. Download Hadoop winutils.exe from:

   https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.0/bin/

2. Copy winutils.exe to 

Alternatively, if you are using RStudio you can install the RStudio Preview Release,
which includes an embedded copy of Hadoop winutils.exe:

  https://www.posit.co/products/rstudio/download/preview/
```
That was confusing because `Installing Spark 3.5.0 for Hadoop 3 or later` contradicts `Download Hadoop winutils.exe from:  https://github.com/steveloughran/winutils/raw/master/hadoop-2.6.0/bin/` (which is not Hadoop 3 or later).
I got it to work by downloading winutils under hadoop-3.0.0/bin, so I suppose this error message should be updated, right?