### PR TITLE
Rappdirs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,7 +86,6 @@ Imports:
     methods,
     openssl (>= 0.8),
     purrr,
-    rappdirs,
     rlang (>= 0.1.4),
     rstudioapi (>= 0.10),
     tibble,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Sparklyr (dev)
+
+- Removes dependency on `rapddirs`: 
+  - Deprecating backwards compatability with `sparklyr` 0.5 is no longer needed
+  - Replicates selection of cache directory 
+
 # Sparklyr 1.8.4
 
 ### Compatability with new `dbplyr` version

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -359,7 +359,7 @@ spark_install_dir <- function() {
 
 # Used for backwards compatibility with sparklyr 0.5 installation path
 spark_install_old_dir <- function() {
-  getOption("spark.install.dir", rappdirs::app_dir("spark", "rstudio")$cache())
+  getOption("spark.install.dir")
 }
 
 #' @rdname spark_install

--- a/R/livy_install.R
+++ b/R/livy_install.R
@@ -173,9 +173,22 @@ livy_versions_file_pattern <- function() {
 #' @rdname livy_install
 #' @export
 livy_install_dir <- function() {
-  normalizePath(
-    getOption("livy.install.dir", rappdirs::app_dir("livy", "rstudio")$cache())
-  )
+  option_dir <- getOption("livy.install.dir")
+  env_dir <- Sys.getenv("R_USER_CONFIG_DIR",unset = NA)
+  if(is.na(env_dir)) {
+    env_dir <- NULL
+  }
+  os <- get_os()
+  cache_dir <- NULL
+  # TODO: Use a more appropiate cache dir for Windows instead of
+  # a temp folder
+  if(os == "win") cache_dir <- file.path(tempdir(), "livy")
+  if(os == "mac") cache_dir <- "~/Library/Caches/livy"
+  if(os == "unix") {
+    cache_dir <- file.path(Sys.getenv("XDG_CACHE_HOME", "~/.cache"), "livy")
+  }
+  path <- option_dir %||% env_dir %||% cache_dir
+  normalizePath(path)
 }
 
 #' @rdname livy_install

--- a/R/livy_install.R
+++ b/R/livy_install.R
@@ -180,9 +180,7 @@ livy_install_dir <- function() {
   }
   os <- get_os()
   cache_dir <- NULL
-  # TODO: Use a more appropiate cache dir for Windows instead of
-  # a temp folder
-  if(os == "win") cache_dir <- file.path(tempdir(), "livy")
+  if(os == "win") cache_dir <-" %LOCALAPPDATA%/livy"
   if(os == "mac") cache_dir <- "~/Library/Caches/livy"
   if(os == "unix") {
     cache_dir <- file.path(Sys.getenv("XDG_CACHE_HOME", "~/.cache"), "livy")

--- a/R/utils.R
+++ b/R/utils.R
@@ -587,8 +587,18 @@ infer_required_r_packages <- function(fn) {
   ls(deps)
 }
 
+get_os <- function() {
+  if (.Platform$OS.type == "windows") {
+    "win"
+  } else if (Sys.info()["sysname"] == "Darwin") {
+    "mac"
+  } else {
+    "unix"
+  }
+}
+
 os_is_windows <- function() {
-  .Platform$OS.type == "windows"
+  get_os() == "windows"
 }
 
 cast_string <- function(x) {


### PR DESCRIPTION
- Removes dependency on `rapddirs`: 
  - Deprecating backwards compatability with `sparklyr` 0.5 is no longer needed
  - Replicates selection of cache directory 