### PR TITLE
Fix warnings with dbplyr and raw columns

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -484,7 +484,7 @@ simulate_vars_spark <- function(x, drop_groups = FALSE) {
     lapply(
       function(x) {
         fn <- tryCatch(
-          get(paste0("as.", x), envir = parent.frame()),
+          get(paste0(x), envir = parent.frame()),
           error = function(e) {
             NULL
           }
@@ -493,7 +493,7 @@ simulate_vars_spark <- function(x, drop_groups = FALSE) {
         if (is.null(fn)) {
           list()
         } else {
-          fn(NA)
+          fn(0)
         }
       }
     ) %>%


### PR DESCRIPTION
Code was trying to do as.raw(NA) which creates a warning.
Replaced with a version that does creates a zero-row tibble with the right types.

Should fix https://github.com/sparklyr/sparklyr/issues/3357