### PR TITLE
fix: Error in `src_databases()` when connected through the Spark Connect method

### DIFF
--- a/R/sdf_wrapper.R
+++ b/R/sdf_wrapper.R
@@ -144,7 +144,11 @@ sdf_read_column <- function(x, column) {
 #' @export
 sdf_read_column.spark_jobj <- function(x, column) {
   sdf <- spark_dataframe(x)
-  col_df <- invoke(sdf, "select", column, list())
+  if (inherits(sdf, "spark_pyobj")) {
+    col_df <- invoke(sdf, "select", list(column))
+  } else {
+    col_df <- invoke(sdf, "select", column, list())
+  }
   col_df <- collect(col_df)
   col_df[[column]]
 }


### PR DESCRIPTION
I propose adding a condition to handle cases where the connection method is Spark Connect.
This could fix the following issues:
https://github.com/sparklyr/sparklyr/issues/3461
https://github.com/sparklyr/sparklyr/issues/3465